### PR TITLE
feat!: pass all posts to blog post template function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,10 @@ There is no single-test runner flag in gleeunit; to run a specific test module, 
 - **`blogatto`** — Main entry point. Exposes `build(Config(msg)) -> Result(Nil, BuildError)` which orchestrates the entire build pipeline.
 - **`blogatto/config`** — Configuration builder (`Config(msg)` generic type) with functional composition. Routes are defined via `config.route(path, view)` where the view function receives the list of parsed blog posts (`List(Post(msg))`).
   - `config/feed` — RSS feed configuration (`FeedConfig`, `FeedMetadata`, `FeedItem`)
-  - `config/markdown` — Markdown rendering config: Maud components, markdown search paths, and optional blog post template override
+  - `config/markdown` — Markdown rendering config: Maud components, markdown search paths, excerpt length, and optional blog post template override
   - `config/sitemap` — Sitemap generation config (`SitemapConfig`, `SitemapEntry`, `ChangeFrequency`)
   - `config/robots` — Robots.txt generation config
-- **`blogatto/post`** — `Post(msg)` type representing a parsed blog post with title, slug, date, description, language, optional featured image, rendered contents, and extras dict.
+- **`blogatto/post`** — `Post(msg)` type representing a parsed blog post with title, slug, date, description, excerpt, language, optional featured image, rendered contents, and extras dict.
 
 ### Internal Modules (not public API)
 
@@ -48,7 +48,7 @@ There is no single-test runner flag in gleeunit; to run a specific test module, 
 1. **Clean** — Delete and recreate `output_dir`
 2. **Copy static assets** — If `static_dir` is set, copy contents to `output_dir`
 3. **Build robots.txt** — If configured, generate via webls
-4. **Build blog pages** — Walk `markdown_config.paths`, find `index.md`/`index-{lang}.md` per directory, extract frontmatter, render via Maud components, construct `Post(msg)` values, write HTML pages via `markdown_config.template` (or default template) to `output_dir/{slug}/index.html` or `output_dir/{slug}/index-{lang}.html`. Copy non-markdown assets (images, etc.) from each post's source directory to the output post directory. Produces `List(Post(msg))` used by subsequent steps.
+4. **Build blog pages** — Walk `markdown_config.paths`, find `index.md`/`index-{lang}.md` per directory, extract frontmatter, render via Maud components, generate plain-text excerpt (truncated to `markdown_config.excerpt_len`), construct `Post(msg)` values, write HTML pages via `markdown_config.template` (or default template, which receives both the current post and all other posts) to `output_dir/{slug}/index.html` or `output_dir/{slug}/index-{lang}.html`. Copy non-markdown assets (images, etc.) from each post's source directory to the output post directory. Produces `List(Post(msg))` used by subsequent steps.
 5. **Build static pages** — For each route in `config.routes`, call the view function with the `List(Post(msg))` from step 4, write HTML
 6. **Build feeds** — For each `FeedConfig`, filter/serialize posts into RSS via webls
 7. **Build sitemap** — If configured, collect all routes and blog post URLs, apply filter/serialize, generate XML

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Blogatto generates your entire static site from a single configuration: blog pos
 ## Installation
 
 ```sh
-gleam add blogatto@1
+gleam add blogatto@2
 gleam add lustre@5
 ```
 

--- a/docs/blog-posts.md
+++ b/docs/blog-posts.md
@@ -162,6 +162,7 @@ After parsing, each markdown file produces a `Post(msg)` value with these fields
 | `url` | `String` | Absolute URL (e.g., `"https://example.com/blog/my-post"`) |
 | `date` | `Timestamp` | From frontmatter |
 | `description` | `String` | From frontmatter |
+| `excerpt` | `String` | Auto-generated plain-text excerpt from rendered content, truncated to `excerpt_len` characters |
 | `language` | `Option(String)` | `None` for default, `Some("it")` for variants |
 | `featured_image` | `Option(String)` | From frontmatter, if provided |
 | `contents` | `List(Element(msg))` | Rendered markdown as Lustre elements |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,7 @@ let md =
   markdown.default()
   |> markdown.markdown_path("./blog")
   |> markdown.route_prefix("blog")
+  |> markdown.excerpt_len(300)
   |> markdown.template(post_template)
 
 let cfg =

--- a/docs/example.md
+++ b/docs/example.md
@@ -182,7 +182,7 @@ Key points:
 The template function wraps each blog post's rendered markdown in a full HTML page:
 
 ```gleam
-fn blog_post_template(p: Post(Nil)) -> Element(Nil) {
+fn blog_post_template(p: Post(Nil), _all_posts: List(Post(Nil))) -> Element(Nil) {
   let lang = option.unwrap(p.language, "en")
 
   html.html([attribute.lang(lang)], [
@@ -227,6 +227,7 @@ fn blog_post_template(p: Post(Nil)) -> Element(Nil) {
 Key points:
 
 - `p.language` is `None` for the default language and `Some("it")` for localized variants — here it falls back to `"en"`
+- `_all_posts` gives access to all other posts (useful for related posts, navigation, etc.)
 - `p.contents` is a `List(Element(Nil))` containing the rendered markdown — just drop it into a container element
 - The template adds a navigation link back to the homepage
 - SEO metadata (`title`, `description`) is set from the post's frontmatter fields

--- a/docs/rss-feeds.md
+++ b/docs/rss-feeds.md
@@ -24,7 +24,7 @@ let cfg =
   |> config.feed(rss)
 ```
 
-This generates `dist/rss.xml` containing all blog posts with auto-generated excerpts of up to 200 characters.
+This generates `dist/rss.xml` containing all blog posts with auto-generated excerpts. The excerpt length is controlled by `markdown.excerpt_len()` (default: 200 characters).
 
 ## FeedConfig fields
 

--- a/docs/static-pages.md
+++ b/docs/static-pages.md
@@ -164,7 +164,7 @@ let md =
   |> markdown.markdown_path("./blog")
   |> markdown.template(post_template)
 
-fn post_template(post: Post(Nil)) -> Element(Nil) {
+fn post_template(post: Post(Nil), _all_posts: List(Post(Nil))) -> Element(Nil) {
   let lang = option.unwrap(post.language, "en")
 
   html.html([attribute.lang(lang)], [
@@ -189,4 +189,4 @@ fn post_template(post: Post(Nil)) -> Element(Nil) {
 }
 ```
 
-The template receives a fully parsed `Post` with rendered `contents`. When no template is set, Blogatto uses a minimal default that wraps the title and contents in a basic HTML page.
+The template receives a fully parsed `Post` with rendered `contents`, and the list of all other posts (useful for related posts, navigation, etc.). When no template is set, Blogatto uses a minimal default that wraps the title and contents in a basic HTML page.

--- a/examples/simple_blog/src/simple_blog/blog.gleam
+++ b/examples/simple_blog/src/simple_blog/blog.gleam
@@ -114,7 +114,7 @@ fn home_view(posts: List(Post(Nil))) -> Element(Nil) {
 
 /// Blog post template: renders a full HTML page for a single blog post
 /// with a navigation link back to the homepage.
-fn blog_post_template(p: Post(Nil)) -> Element(Nil) {
+fn blog_post_template(p: Post(Nil), _all_posts: List(Post(Nil))) -> Element(Nil) {
   let lang = option.unwrap(p.language, "en")
 
   html.html([attribute.lang(lang)], [

--- a/src/blogatto/config/markdown.gleam
+++ b/src/blogatto/config/markdown.gleam
@@ -94,9 +94,9 @@ pub type MarkdownConfig(msg) {
     /// posts are written to `output_dir/blog/{slug}/index.html`.
     route_prefix: Option(String),
     /// Optional custom template for rendering a blog post page.
-    /// Receives the parsed `Post` and returns a full page element.
+    /// Receives the parsed `Post`, and all the other posts, and returns a full page element.
     /// When `None`, Blogatto uses a minimal default template.
-    template: Option(fn(Post(msg)) -> Element(msg)),
+    template: Option(fn(Post(msg), List(Post(msg))) -> Element(msg)),
   )
 }
 
@@ -162,11 +162,11 @@ pub fn route_prefix(
 /// Set a custom template function for rendering blog post pages.
 ///
 /// The template receives a fully parsed `Post` (with rendered contents)
-/// and returns the complete page element. When not set, Blogatto uses
+/// and all the other posts, and returns the complete page element. When not set, Blogatto uses
 /// a minimal default template with the post title and contents.
 pub fn template(
   config: MarkdownConfig(msg),
-  template: fn(Post(msg)) -> Element(msg),
+  template: fn(Post(msg), List(Post(msg))) -> Element(msg),
 ) -> MarkdownConfig(msg) {
   MarkdownConfig(..config, template: option.Some(template))
 }

--- a/src/blogatto/internal/builder/blog.gleam
+++ b/src/blogatto/internal/builder/blog.gleam
@@ -71,7 +71,11 @@ pub fn build(
       use posts <- result.try(parse_all_posts_dir(config, markdown_config))
       use built_posts <- result.try(
         list.try_map(posts, fn(post_info) {
-          build_post(post_info, markdown_config)
+          let other_posts =
+            posts
+            |> list.filter(fn(p) { p.post.slug != post_info.post.slug })
+            |> list.map(fn(p) { p.post })
+          build_post(post_info, markdown_config, other_posts)
         }),
       )
       // Sort posts by date, newest first.
@@ -92,6 +96,7 @@ pub fn build(
 fn build_post(
   post_info: PostInfo(msg),
   markdown_config: markdown.MarkdownConfig(msg),
+  all_posts: List(post.Post(msg)),
 ) -> Result(post.Post(msg), error.BlogattoError) {
   // create the output directory for the post if it doesn't exist
   use _ <- result.try(
@@ -104,7 +109,7 @@ fn build_post(
     option.unwrap(markdown_config.template, or: default_template)
   let html_content =
     post_info.post
-    |> render_template()
+    |> render_template(all_posts)
     |> element.to_document_string()
   // write the HTML file
   use _ <- result.try(
@@ -130,7 +135,10 @@ fn build_post(
 /// Default template to use to wrap the rendered markdown content of a blog post.
 /// Uses the post's language for the `lang` attribute (falls back to `"en"`),
 /// includes a viewport meta tag, and preloads the featured image when present.
-fn default_template(post: post.Post(msg)) -> element.Element(msg) {
+fn default_template(
+  post: post.Post(msg),
+  _all_posts: List(post.Post(msg)),
+) -> element.Element(msg) {
   let lang = option.unwrap(post.language, "en")
   html.html([attribute.lang(lang)], [
     html.head([], [

--- a/test/blogatto/builder/blog_test.gleam
+++ b/test/blogatto/builder/blog_test.gleam
@@ -84,7 +84,7 @@ fn prefixed_config(
 fn config_with_template(
   output_dir: String,
   blog_dir: String,
-  tmpl: fn(post.Post(msg)) -> element.Element(msg),
+  tmpl: fn(post.Post(msg), List(post.Post(msg))) -> element.Element(msg),
 ) -> config.Config(msg) {
   let md_config =
     markdown.default()
@@ -735,7 +735,10 @@ pub fn build_with_custom_template_applies_template_test() {
       ),
     )
 
-    let custom_template = fn(p: post.Post(msg)) -> element.Element(msg) {
+    let custom_template = fn(
+      p: post.Post(msg),
+      _all_posts: List(post.Post(msg)),
+    ) -> element.Element(msg) {
       html.html([], [
         html.head([], [html.title([], p.title)]),
         html.body([], [

--- a/test/blogatto/config/markdown_test.gleam
+++ b/test/blogatto/config/markdown_test.gleam
@@ -60,7 +60,7 @@ pub fn markdown_path_prepends_multiple_paths_test() {
 // --- template ---
 
 pub fn template_sets_template_function_test() {
-  let tmpl = fn(_post) { html.div([], [html.text("custom")]) }
+  let tmpl = fn(_post, _all_posts) { html.div([], [html.text("custom")]) }
   let cfg =
     markdown.default()
     |> markdown.template(tmpl)


### PR DESCRIPTION
## Summary

- **Breaking change**: template function signature changes from `fn(Post(msg)) -> Element(msg)` to `fn(Post(msg), List(Post(msg))) -> Element(msg)`, giving templates access to all other posts for related posts, navigation, etc.
- Updated all documentation (blog-posts, static-pages, example, configuration, rss-feeds, CLAUDE.md, README) to reflect the new signature and excerpt changes
- Updated the `simple_blog` example to use the new template signature

Closes #5

## Test plan

- [x] All 346 tests pass
- [x] Example project compiles
- [x] Code formatted