### PR TITLE
fix: link GitHub to repo and fix OG preview on docs site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,8 @@
 title: Blogatto
 description: A Gleam framework for building static blogs with Lustre and Markdown
+url: https://veeso.github.io
+baseurl: /blogatto
 theme: minima
-image: /og_preview.jpeg
-github_username: veeso
+image: /blogatto/og_preview.jpeg
+github_url: https://github.com/veeso/blogatto
 codeberg_url: https://codeberg.org/veeso/blogatto

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -24,8 +24,8 @@
             {%- endif -%}
           {%- endfor -%}
 
-          {%- if site.github_username -%}
-          <a class="page-link" href="https://github.com/{{ site.github_username | cgi_escape | escape }}" title="GitHub">
+          {%- if site.github_url -%}
+          <a class="page-link" href="{{ site.github_url | escape }}" title="GitHub">
             <svg class="svg-icon" style="vertical-align: middle;"><use xlink:href="{{ '/assets/minima-social-icons.svg#github' | relative_url }}"></use></svg>
           </a>
           {%- endif -%}

--- a/docs/_includes/social.html
+++ b/docs/_includes/social.html
@@ -1,4 +1,4 @@
 <ul class="social-media-list">
-  {%- if site.github_username -%}<li><a href="https://github.com/{{ site.github_username | cgi_escape | escape }}"><svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#github' | relative_url }}"></use></svg> <span class="username">{{ site.github_username | escape }}</span></a></li>{%- endif -%}
+  {%- if site.github_url -%}<li><a href="{{ site.github_url | escape }}"><svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#github' | relative_url }}"></use></svg> <span class="username">GitHub</span></a></li>{%- endif -%}
   {%- if site.codeberg_url -%}<li><a href="{{ site.codeberg_url | escape }}"><svg class="svg-icon" viewBox="0 0 16 16"><path fill="#2185D0" d="M11.955.49A5 5 0 0 0 8 0C5.628 0 3.572 1.6 2.876 3.834c-.008.026-.01.054-.018.08C1.728 4.555.875 5.483.875 6.592c0 .262.05.513.14.742-.09.254-.14.527-.14.81 0 .91.498 1.702 1.234 2.128L8 16l5.891-5.728a2.611 2.611 0 0 0 1.234-2.128c0-.283-.05-.556-.14-.81.09-.229.14-.48.14-.742 0-1.533-1.458-2.768-3.17-2.768z"/></svg> <span class="username">Codeberg</span></a></li>{%- endif -%}
 </ul>


### PR DESCRIPTION
## Summary

- Changed GitHub link on docs site to point to the repository (`veeso/blogatto`) instead of the user profile (`veeso`)
- Fixed OG preview image by adding `url` and `baseurl` to Jekyll config so `jekyll-seo-tag` generates a full absolute URL for `og:image`
- Added favicon link to docs site

## Test plan

- [ ] Verify GitHub icon in header/footer links to `https://github.com/veeso/blogatto`
- [ ] Verify OG preview image resolves correctly when sharing the docs site URL