### PR TITLE
fix: use custom domain URL in docs site config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,8 +1,7 @@
 title: Blogatto
 description: A Gleam framework for building static blogs with Lustre and Markdown
-url: https://veeso.github.io
-baseurl: /blogatto
+url: https://blogat.to
 theme: minima
-image: /blogatto/og_preview.jpeg
+image: /og_preview.jpeg
 github_url: https://github.com/veeso/blogatto
 codeberg_url: https://codeberg.org/veeso/blogatto


### PR DESCRIPTION
## Summary

- Fix `url` in `_config.yml` from `https://veeso.github.io` to `https://blogat.to` (the actual custom domain)
- Remove unnecessary `baseurl: /blogatto` which caused all relative URLs (CSS, JS, favicon, images) to 404
- Fix OG preview image path to `/og_preview.jpeg` (no `/blogatto` prefix)

## Test plan

- [ ] Verify docs site loads at https://blogat.to
- [ ] Verify CSS/JS assets load correctly
- [ ] Verify favicon and OG preview image render