### PR TITLE
fix: add explicit og:image meta tag to docs site

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,6 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
+  <meta property="og:image" content="{{ site.url }}{{ site.image }}" />
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
   {%- feed_meta -%}


### PR DESCRIPTION
## Summary

- Add explicit `og:image` meta tag in `head.html` since `jekyll-seo-tag` was not generating it from `site.image` config
- OG preview image now resolves to `https://blogat.to/og_preview.jpeg`

## Test plan

- [ ] Verify `og:image` meta tag appears in rendered HTML head
- [ ] Verify OG preview works when sharing the docs site URL