### PR TITLE
feat: add route_builder to MarkdownConfig for custom blog post routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Blogatto generates your entire static site from a single configuration: blog pos
 ## Installation
 
 ```sh
-gleam add blogatto@2
+gleam add blogatto@3
 gleam add lustre@5
 ```
 

--- a/docs/blog-posts.md
+++ b/docs/blog-posts.md
@@ -119,6 +119,58 @@ Without a `route_prefix`:
 | `hello-world/index.md` | `dist/hello-world/index.html` |
 | `hello-world/index-it.md` | `dist/it/hello-world/index.html` |
 
+### Custom routing with `route_builder`
+
+For full control over post URLs, use `markdown.route_builder()` instead of `route_prefix`. The route builder receives a `PostMetadata` value and returns the URL path for that post. When set, the `route_prefix` is ignored.
+
+```gleam
+import blogatto/config/markdown
+import blogatto/post
+import gleam/int
+import gleam/option
+import gleam/time/calendar
+
+let md =
+  markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.route_builder(fn(meta: post.PostMetadata) {
+    let #(year, month, _day) = calendar.to_date(meta.date)
+    "/blog/" <> int.to_string(year) <> "/" <> int.to_string(month) <> "/" <> meta.slug <> "/"
+  })
+```
+
+This produces date-based URLs like `/blog/2024/1/my-post/` and filesystem paths like `dist/blog/2024/1/my-post/index.html`.
+
+The route builder can also incorporate language:
+
+```gleam
+markdown.route_builder(fn(meta: post.PostMetadata) {
+  let lang_prefix = case meta.language {
+    option.Some(lang) -> "/" <> lang
+    option.None -> ""
+  }
+  lang_prefix <> "/blog/" <> meta.slug <> "/"
+})
+```
+
+Blogatto normalizes the returned path: a leading `/` is added if missing, and a trailing `/` is appended if missing.
+
+#### `PostMetadata` fields
+
+The `PostMetadata` type contains all frontmatter-derived fields available at routing time:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | `String` | From frontmatter |
+| `slug` | `String` | From frontmatter |
+| `date` | `Timestamp` | From frontmatter |
+| `description` | `String` | From frontmatter |
+| `language` | `Option(String)` | `None` for default, `Some("it")` for variants |
+| `featured_image` | `Option(String)` | From frontmatter, if provided |
+| `extras` | `Dict(String, String)` | Additional frontmatter fields |
+
+Note that `PostMetadata` intentionally excludes `url` (which is the output of the route builder), `excerpt`, and `contents` (which are not available at routing time).
+
 ### Filtering posts by language
 
 In route views, filter the post list by language to build language-specific pages:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ For example, `./static/css/style.css` becomes `./dist/css/style.css`.
 
 ### `config.markdown(config, markdown_config)`
 
-Set the markdown configuration for blog post rendering. See [Markdown components](markdown-components) for details on `MarkdownConfig`.
+Set the markdown configuration for blog post rendering. See [Markdown components](markdown-components) for component customization and [Blog posts](blog-posts) for routing details.
 
 ```gleam
 import blogatto/config/markdown
@@ -77,6 +77,15 @@ let md = markdown.default()
 config.new("https://example.com")
 |> config.markdown(md)
 ```
+
+#### Markdown routing options
+
+The `MarkdownConfig` controls how blog post URLs are generated. You can use either `route_prefix` or `route_builder` (not both — `route_builder` takes precedence):
+
+- **`markdown.route_prefix(config, prefix)`** — set a static URL prefix for all posts (e.g., `"blog"` produces `/blog/{slug}/`)
+- **`markdown.route_builder(config, builder)`** — set a function that receives `PostMetadata` and returns a custom URL path per post
+
+See [Custom routing with `route_builder`](blog-posts#custom-routing-with-route_builder) for examples.
 
 ### `config.route(config, path, view)`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ This guide walks you through installing Blogatto and building your first static 
 Add Blogatto to your Gleam project:
 
 ```sh
-gleam add blogatto@1
+gleam add blogatto@3
 ```
 
 ## Project structure

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Blogatto generates your entire static site from a single configuration: blog pos
 - **Sitemap XML** — automatic sitemap generation covering static pages and blog posts
 - **Robots.txt** — configurable crawl policies with sitemap reference
 - **Custom markdown rendering** — override any markdown element's HTML output via Maud components
+- **Custom post routing** — control blog post URLs with a route builder function for date-based, category-based, or any custom URL scheme
 - **Blog post templates** — full control over the page layout wrapping each blog post
 - **Static asset copying** — copy CSS, images, and other assets into the output directory
 

--- a/examples/simple_blog/manifest.toml
+++ b/examples/simple_blog/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "blogatto", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "webls"], source = "local", path = "../.." },
+  { name = "blogatto", version = "3.0.0", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "webls"], source = "local", path = "../.." },
   { name = "casefold", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "casefold", source = "hex", outer_checksum = "F09530B6F771BB7B0BCACD3014089C20DFDA31775BA4793266C3814607C0A468" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,12 +1,12 @@
 name = "blogatto"
-version = "2.0.1"
+version = "3.0.0"
 description = "A Gleam framework for building static blogs with Lustre and Markdown. Generates HTML pages, RSS feeds, sitemaps, and robots.txt from markdown files with frontmatter, with multilingual support."
 repository = { type = "github", user = "veeso", repo = "blogatto" }
 licenses = ["MIT"]
 target = "erlang"
 internal_modules = ["blogatto/internal", "blogatto/internal/*"]
 links = [
-  { title = "Documentation", href = "https://blogat.to" },
+  { title = "Website", href = "https://blogat.to" },
   { title = "Codeberg", href = "https://codeberg.org/veeso/blogatto" },
 ]
 

--- a/src/blogatto/config/markdown.gleam
+++ b/src/blogatto/config/markdown.gleam
@@ -18,7 +18,7 @@
 ////   })
 //// ```
 
-import blogatto/post.{type Post}
+import blogatto/post.{type Post, type PostMetadata}
 import gleam/list
 import gleam/option.{type Option, None}
 import lustre/element.{type Element}
@@ -93,6 +93,12 @@ pub type MarkdownConfig(msg) {
     /// directly under `output_dir/{slug}/index.html`. When `Some("blog")`,
     /// posts are written to `output_dir/blog/{slug}/index.html`.
     route_prefix: Option(String),
+    /// Function to customize the blog post URL.
+    /// It receives the `PostMetadata` and returns the URL path for that post (e.g., `"/my-post/"` or `"/it/my-post/"`).
+    /// When set `route_prefix` is IGNORED! This allows you to have full control over the post URLs,
+    /// including the ability to place them outside of the route prefix or to use a completely different URL structure.
+    /// If not provided the default builder will be used (i.e. `/{route_prefix?}/{lang}/{slug}/` or `/{route_prefix?}/{slug}/` if language is `None`).
+    route_builder: Option(fn(PostMetadata) -> String),
     /// Optional custom template for rendering a blog post page.
     /// Receives the parsed `Post`, and all the other posts, and returns a full page element.
     /// When `None`, Blogatto uses a minimal default template.
@@ -101,13 +107,14 @@ pub type MarkdownConfig(msg) {
 }
 
 /// Create a default `MarkdownConfig` with default components,
-/// no search paths, no route prefix, and no custom template.
+/// no search paths, no route prefix, no custom route builder, and no custom template.
 pub fn default() -> MarkdownConfig(msg) {
   MarkdownConfig(
     components: default_components(),
     excerpt_len: 200,
     paths: [],
     route_prefix: None,
+    route_builder: None,
     template: None,
   )
 }
@@ -157,6 +164,23 @@ pub fn route_prefix(
   prefix: String,
 ) -> MarkdownConfig(msg) {
   MarkdownConfig(..config, route_prefix: option.Some(prefix))
+}
+
+/// Set a custom route builder function for blog post URLs.
+/// 
+/// The route builder receives the `PostMetadata` and returns the URL path for that post (e.g., `"/my-post/"` or `"/it/my-post/"`).
+/// Do not add `index.html` to the returned path.
+/// 
+/// When set, the `route_prefix` field is IGNORED!
+/// This allows you to have full control over the post URLs,
+/// including the ability to place them outside of the route prefix or to use a completely different URL structure.
+/// 
+/// If not provided the default builder will be used (i.e. `/{route_prefix?}/{lang}/{slug}/` or `/{route_prefix?}/{slug}/` if language is `None`).
+pub fn route_builder(
+  config: MarkdownConfig(msg),
+  builder: fn(PostMetadata) -> String,
+) -> MarkdownConfig(msg) {
+  MarkdownConfig(..config, route_builder: option.Some(builder))
 }
 
 /// Set a custom template function for rendering blog post pages.

--- a/src/blogatto/internal/builder/blog.gleam
+++ b/src/blogatto/internal/builder/blog.gleam
@@ -246,13 +246,27 @@ fn parse_post(
 ) -> Result(PostInfo(msg), error.BlogattoError) {
   // parse frontmatter
   use frontmatter <- result.try(parse_frontmatter(markdown_file.content))
-  let html_path =
-    markdown_html_path(
-      config.output_dir,
-      markdown_config.route_prefix,
-      frontmatter.slug,
-      markdown_file,
+
+  // build post metadata
+  let post_metadata =
+    post.PostMetadata(
+      title: frontmatter.title,
+      slug: frontmatter.slug,
+      date: frontmatter.date,
+      description: frontmatter.description,
+      featured_image: frontmatter.featured_image,
+      language: markdown_file.language,
+      extras: frontmatter.extras,
     )
+
+  let url_path =
+    post_url_path(
+      markdown_config.route_prefix,
+      markdown_config.route_builder,
+      post_metadata,
+    )
+  let html_path = markdown_html_path(config.output_dir, url_path)
+  let url = post_url(config.site_url, url_path)
 
   // assets dir is the parent of the HTML file
   let assets_dir = path.parent(html_path)
@@ -266,14 +280,6 @@ fn parse_post(
       options,
       to_maud_components(markdown_config.components),
     )
-  // compute the absolute URL for this post
-  let url =
-    post_url(
-      config.site_url,
-      markdown_config.route_prefix,
-      frontmatter.slug,
-      markdown_file,
-    )
   let excerpt =
     rendered_components
     |> excerpt.extract(markdown_config.excerpt_len)
@@ -284,15 +290,15 @@ fn parse_post(
     assets_dir: assets_dir,
     assets: assets,
     post: post.Post(
-      title: frontmatter.title,
-      slug: frontmatter.slug,
+      title: post_metadata.title,
+      slug: post_metadata.slug,
       url: url,
-      date: frontmatter.date,
-      description: frontmatter.description,
-      featured_image: frontmatter.featured_image,
+      date: post_metadata.date,
+      description: post_metadata.description,
+      featured_image: post_metadata.featured_image,
       excerpt:,
-      language: markdown_file.language,
-      extras: frontmatter.extras,
+      language: post_metadata.language,
+      extras: post_metadata.extras,
       contents: rendered_components,
     ),
   ))
@@ -312,64 +318,81 @@ fn read_markdown_file(
   Ok(MarkdownFile(file_path, content, language))
 }
 
-/// Determine the output HTML path for a given markdown file.
-///
-/// The output path starts with `output_dir`, optionally followed by the
-/// `route_prefix` (e.g., `"blog"`), then a language subdirectory for
-/// localized posts, the slug, and finally `index.html`.
-///
-/// For instance given `output_dir = "./dist"`, `route_prefix = Some("blog")`,
-/// `slug = "my-post"`, and `language = Some("en")`, the result is
-/// `"./dist/blog/en/my-post/index.html"`.
-///
-/// When `route_prefix` is `None`, the prefix segment is omitted:
-/// `"./dist/my-post/index.html"` or `"./dist/en/my-post/index.html"`.
-fn markdown_html_path(
-  output_dir: String,
+/// Compute the URL path for a blog post based on the optional route prefix, optional route builder, and post metadata.
+/// 
+/// This function returns the URL path relative to the site root, which is used for linking the post in the feed and sitemap, and for computing the output HTML path.
+fn post_url_path(
   route_prefix: Option(String),
-  slug: String,
-  file: MarkdownFile,
+  route_builder: Option(fn(post.PostMetadata) -> String),
+  metadata: post.PostMetadata,
 ) -> String {
-  let base = case route_prefix {
-    option.Some(prefix) -> path.join(output_dir, prefix)
-    option.None -> output_dir
+  case route_builder {
+    option.Some(builder) -> post_url_path_from_route_builder(builder, metadata)
+    option.None -> post_url_path_from_prefix(route_prefix, metadata)
   }
-  let base = case file.language {
-    option.Some(lang) -> path.join(base, lang)
-    option.None -> base
+}
+
+/// Compute the URL path for a blog post based on the route builder and post metadata.
+/// 
+/// The output of the `route_builder` is used as-is with some sanitization: if it doesn't end with a trailing slash, one is added.
+fn post_url_path_from_route_builder(
+  route_builder: fn(post.PostMetadata) -> String,
+  post_metadata: post.PostMetadata,
+) -> String {
+  let url =
+    post_metadata
+    |> route_builder
+    |> string.trim
+    |> string.replace("index.html", "")
+
+  let url = case string.starts_with(url, "/") {
+    True -> url
+    False -> "/" <> url
   }
-  base
-  |> path.join(slug)
+
+  case string.ends_with(url, "/") {
+    True -> url
+    False -> url <> "/"
+  }
+}
+
+/// Compute the URL path for a blog post based on the optional route prefix and post metadata.
+/// 
+/// The URL path is constructed using the optional `route_prefix`, optional language subdirectory, slug,
+/// and always ends with a trailing slash. For example, given `route_prefix = Some("blog")`,
+/// `slug = "my-post"`, and `language = None`, the result is `"/blog/my-post/"`.
+fn post_url_path_from_prefix(
+  route_prefix: Option(String),
+  post_metadata: post.PostMetadata,
+) -> String {
+  let prefix = case route_prefix {
+    option.Some(prefix) -> "/" <> prefix
+    option.None -> ""
+  }
+  let lang = case post_metadata.language {
+    option.Some(lang) -> "/" <> lang
+    option.None -> ""
+  }
+  prefix <> lang <> "/" <> post_metadata.slug <> "/"
+}
+
+/// Determine the output HTML path for a blog post based on the output directory and its URL path from the site root.
+fn markdown_html_path(output_dir: String, path: String) -> String {
+  output_dir
+  |> path.join(path)
   |> path.join("index.html")
 }
 
 /// Compute the absolute URL for a blog post.
 ///
-/// Combines `site_url` with the optional `route_prefix`, optional language,
-/// and slug, always ending with a trailing slash. For example, given
-/// `site_url = "https://example.com"`, `route_prefix = Some("blog")`,
-/// `slug = "my-post"`, and `language = Some("it")`, the result is
-/// `"https://example.com/blog/it/my-post/"`.
-fn post_url(
-  site_url: String,
-  route_prefix: Option(String),
-  slug: String,
-  file: MarkdownFile,
-) -> String {
+/// Combines `site_url` with the URL path from the site root.
+fn post_url(site_url: String, path: String) -> String {
   // Strip trailing slash from site_url to avoid double slashes.
   let base = case string.ends_with(site_url, "/") {
     True -> string.drop_end(site_url, 1)
     False -> site_url
   }
-  let relative = case route_prefix {
-    option.Some(prefix) -> "/" <> prefix
-    option.None -> ""
-  }
-  let relative = case file.language {
-    option.Some(lang) -> relative <> "/" <> lang
-    option.None -> relative
-  }
-  base <> relative <> "/" <> slug <> "/"
+  base <> path
 }
 
 /// Helper function to parse the frontmatter of a markdown file and extract the required fields (title, slug, date, description) along with any additional fields.

--- a/src/blogatto/post.gleam
+++ b/src/blogatto/post.gleam
@@ -56,3 +56,24 @@ pub type Post(msg) {
     extras: Dict(String, String),
   )
 }
+
+/// Post metadata is used to provide the user the information to implement a custom route builder for the posts.
+pub type PostMetadata {
+  PostMetadata(
+    /// The post title, extracted from the `title` frontmatter field.
+    title: String,
+    /// URL-friendly identifier derived from the post's directory name.
+    slug: String,
+    /// Publication date extracted from the `date` frontmatter field.
+    date: timestamp.Timestamp,
+    /// Short description extracted from the `description` frontmatter field.
+    description: String,
+    /// The language of this post variant, or `None` for the default language.
+    /// Derived from the filename: `index-it.md` produces `Some("it")`.
+    language: Option(String),
+    /// The featured image URL extracted from the `featured_image` frontmatter field, or `None` if not provided.
+    featured_image: Option(String),
+    /// Additional frontmatter keys beyond the required fields.
+    extras: Dict(String, String),
+  )
+}

--- a/test/blogatto/builder/blog_test.gleam
+++ b/test/blogatto/builder/blog_test.gleam
@@ -96,6 +96,40 @@ fn config_with_template(
   |> config.markdown(md_config)
 }
 
+/// Config with a custom route_builder.
+fn route_builder_config(
+  output_dir: String,
+  blog_dir: String,
+  builder: fn(post.PostMetadata) -> String,
+) -> config.Config(msg) {
+  let md_config =
+    markdown.default()
+    |> markdown.markdown_path(blog_dir)
+    |> markdown.route_builder(builder)
+
+  config.new("https://example.com")
+  |> config.output_dir(output_dir)
+  |> config.markdown(md_config)
+}
+
+/// Config with both route_prefix and route_builder (builder should win).
+fn route_builder_with_prefix_config(
+  output_dir: String,
+  blog_dir: String,
+  prefix: String,
+  builder: fn(post.PostMetadata) -> String,
+) -> config.Config(msg) {
+  let md_config =
+    markdown.default()
+    |> markdown.markdown_path(blog_dir)
+    |> markdown.route_prefix(prefix)
+    |> markdown.route_builder(builder)
+
+  config.new("https://example.com")
+  |> config.output_dir(output_dir)
+  |> config.markdown(md_config)
+}
+
 fn create_post_dir(blog_dir: String, slug: String) -> String {
   let post_dir = blog_dir <> "/" <> slug
   let assert Ok(_) = simplifile.create_directory_all(post_dir)
@@ -1409,5 +1443,237 @@ pub fn build_route_prefix_copies_assets_under_prefix_test() {
     simplifile.read(assets_dir <> "/photo.png")
     |> should.be_ok
     |> should.equal("image-bytes")
+  }
+}
+
+// --- route_builder ---
+
+pub fn build_with_route_builder_places_html_at_custom_path_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "rb-post")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Route Builder Post",
+        "rb-post",
+        "2024-01-15 10:00:00",
+        "A custom routed post",
+        "# Hello\n",
+      ),
+    )
+
+    let builder = fn(metadata: post.PostMetadata) -> String {
+      "/custom/" <> metadata.slug <> "/"
+    }
+
+    route_builder_config(dir, blog, builder)
+    |> blog_builder.build()
+    |> should.be_ok
+
+    let html_path =
+      path.join(dir, "custom")
+      |> path.join("rb-post")
+      |> path.join("index.html")
+
+    simplifile.is_file(html_path)
+    |> should.be_ok
+    |> should.be_true
+  }
+}
+
+pub fn build_with_route_builder_sets_correct_post_url_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "url-post")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "URL Post",
+        "url-post",
+        "2024-01-15 10:00:00",
+        "Post with custom URL",
+        "# Hello\n",
+      ),
+    )
+
+    let builder = fn(metadata: post.PostMetadata) -> String {
+      "/articles/" <> metadata.slug <> "/"
+    }
+
+    let assert [built_post] =
+      route_builder_config(dir, blog, builder)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    built_post.url
+    |> should.equal("https://example.com/articles/url-post/")
+  }
+}
+
+pub fn build_with_route_builder_ignores_route_prefix_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "ignore-prefix")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Ignore Prefix",
+        "ignore-prefix",
+        "2024-01-15 10:00:00",
+        "Route builder should win over prefix",
+        "# Hello\n",
+      ),
+    )
+
+    let builder = fn(metadata: post.PostMetadata) -> String {
+      "/custom/" <> metadata.slug <> "/"
+    }
+
+    // Both prefix and builder set; builder should take precedence
+    route_builder_with_prefix_config(dir, blog, "blog", builder)
+    |> blog_builder.build()
+    |> should.be_ok
+
+    // HTML should be at /custom/ignore-prefix/, NOT /blog/ignore-prefix/
+    let custom_path =
+      path.join(dir, "custom")
+      |> path.join("ignore-prefix")
+      |> path.join("index.html")
+
+    simplifile.is_file(custom_path)
+    |> should.be_ok
+    |> should.be_true
+
+    // The prefixed path should NOT exist
+    let prefixed_path =
+      expected_prefixed_html_path(dir, "blog", "ignore-prefix")
+
+    simplifile.is_file(prefixed_path)
+    |> should.be_ok
+    |> should.be_false
+  }
+}
+
+pub fn build_with_route_builder_adds_trailing_slash_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "no-slash")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "No Slash",
+        "no-slash",
+        "2024-01-15 10:00:00",
+        "Builder returns path without trailing slash",
+        "# Hello\n",
+      ),
+    )
+
+    // Return path WITHOUT trailing slash
+    let builder = fn(metadata: post.PostMetadata) -> String {
+      "/posts/" <> metadata.slug
+    }
+
+    let assert [built_post] =
+      route_builder_config(dir, blog, builder)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    // URL should still have trailing slash
+    built_post.url
+    |> should.equal("https://example.com/posts/no-slash/")
+  }
+}
+
+pub fn build_with_route_builder_adds_leading_slash_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "no-lead")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "No Lead Slash",
+        "no-lead",
+        "2024-01-15 10:00:00",
+        "Builder returns path without leading slash",
+        "# Hello\n",
+      ),
+    )
+
+    // Return path WITHOUT leading slash
+    let builder = fn(metadata: post.PostMetadata) -> String {
+      "posts/" <> metadata.slug <> "/"
+    }
+
+    let assert [built_post] =
+      route_builder_config(dir, blog, builder)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    // URL should have leading slash (no malformed URL)
+    built_post.url
+    |> should.equal("https://example.com/posts/no-lead/")
+  }
+}
+
+pub fn build_with_route_builder_using_language_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "lang-rb")
+    write_markdown(
+      post_dir,
+      "index-it.md",
+      markdown_content(
+        "Ciao",
+        "lang-rb",
+        "2024-01-15 10:00:00",
+        "Italian post with route builder",
+        "# Ciao\n",
+      ),
+    )
+
+    let builder = fn(metadata: post.PostMetadata) -> String {
+      let lang = case metadata.language {
+        option.Some(lang) -> lang <> "/"
+        option.None -> ""
+      }
+      "/" <> lang <> "blog/" <> metadata.slug <> "/"
+    }
+
+    let assert [built_post] =
+      route_builder_config(dir, blog, builder)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    built_post.url
+    |> should.equal("https://example.com/it/blog/lang-rb/")
+
+    let html_path =
+      path.join(dir, "it")
+      |> path.join("blog")
+      |> path.join("lang-rb")
+      |> path.join("index.html")
+
+    simplifile.is_file(html_path)
+    |> should.be_ok
+    |> should.be_true
   }
 }

--- a/test/blogatto/config/markdown_test.gleam
+++ b/test/blogatto/config/markdown_test.gleam
@@ -19,6 +19,18 @@ pub fn default_has_no_template_test() {
   |> should.equal(None)
 }
 
+pub fn default_has_no_route_builder_test() {
+  let cfg = markdown.default()
+  cfg.route_builder
+  |> should.equal(None)
+}
+
+pub fn default_has_no_route_prefix_test() {
+  let cfg = markdown.default()
+  cfg.route_prefix
+  |> should.equal(None)
+}
+
 pub fn default_components_renders_paragraph_test() {
   let comps = markdown.default_components()
   let result = comps.p([html.text("hello")])
@@ -33,6 +45,29 @@ pub fn default_components_renders_h1_test() {
   result
   |> element.to_string
   |> should.equal("<h1 id=\"title\">Title</h1>")
+}
+
+//  --- route_prefix ---
+
+pub fn route_prefix_adds_prefix_to_url_test() {
+  let cfg =
+    markdown.default()
+    |> markdown.route_prefix("blog")
+
+  cfg.route_prefix
+  |> should.equal(Some("blog"))
+}
+
+// --- route_builder ---
+
+pub fn route_builder_overrides_default_url_test() {
+  let builder = fn(_metadata) { "/custom-url/" }
+  let cfg =
+    markdown.default()
+    |> markdown.route_builder(builder)
+
+  cfg.route_builder
+  |> should.equal(Some(builder))
 }
 
 // --- markdown_path ---

--- a/test/blogatto/internal/dev/web_server_test.gleam
+++ b/test/blogatto/internal/dev/web_server_test.gleam
@@ -124,7 +124,7 @@ fn url(port: Int, path: String) -> String {
 }
 
 pub fn serve_html_page_test() {
-  let port = 49_152
+  let port = 20_152
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) =
@@ -149,7 +149,7 @@ pub fn serve_html_page_test() {
 }
 
 pub fn serve_html_page_without_live_reload_test() {
-  let port = 49_153
+  let port = 20_153
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) =
@@ -173,7 +173,7 @@ pub fn serve_html_page_without_live_reload_test() {
 }
 
 pub fn serve_nested_page_test() {
-  let port = 49_154
+  let port = 20_154
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) = simplifile.create_directory_all(output_dir <> "/about")
@@ -196,7 +196,7 @@ pub fn serve_nested_page_test() {
 }
 
 pub fn serve_missing_page_returns_404_test() {
-  let port = 49_155
+  let port = 20_155
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
 
@@ -212,7 +212,7 @@ pub fn serve_missing_page_returns_404_test() {
 }
 
 pub fn serve_static_asset_test() {
-  let port = 49_156
+  let port = 20_156
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) =
@@ -235,7 +235,7 @@ pub fn serve_static_asset_test() {
 }
 
 pub fn serve_missing_asset_returns_404_test() {
-  let port = 49_157
+  let port = 20_157
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
 
@@ -251,7 +251,7 @@ pub fn serve_missing_asset_returns_404_test() {
 }
 
 pub fn path_traversal_page_returns_404_test() {
-  let port = 49_158
+  let port = 20_158
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) =
@@ -273,7 +273,7 @@ pub fn path_traversal_page_returns_404_test() {
 }
 
 pub fn path_traversal_asset_returns_404_test() {
-  let port = 49_159
+  let port = 20_159
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
 
@@ -290,7 +290,7 @@ pub fn path_traversal_asset_returns_404_test() {
 }
 
 pub fn serve_html_page_has_no_cache_headers_test() {
-  let port = 49_160
+  let port = 20_160
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) =
@@ -311,7 +311,7 @@ pub fn serve_html_page_has_no_cache_headers_test() {
 }
 
 pub fn serve_nested_page_without_trailing_slash_redirects_test() {
-  let port = 49_161
+  let port = 20_161
   let assert Ok(_) = {
     use output_dir <- temporary.create(temporary.directory())
     let assert Ok(_) = simplifile.create_directory_all(output_dir <> "/about")


### PR DESCRIPTION
## Summary

- Add optional `route_builder` function to `MarkdownConfig` for full control over blog post URLs (date-based, category-based, or any custom scheme)
- Introduce `PostMetadata` type in `blogatto/post` with frontmatter-derived fields available at routing time
- When `route_builder` is set, `route_prefix` is ignored — the builder has full control over the route
- Blogatto normalizes the builder output (ensures leading `/` and trailing `/`)

## Breaking changes

`MarkdownConfig` gained a new `route_builder` field. Code that constructs `MarkdownConfig` records directly (rather than via `markdown.default()` + setters) will need to add `route_builder: option.None` to the constructor. The builder pattern API is unaffected.

Version bumped to **3.0.0**.

## Test plan

- [x] Existing 363 tests still pass (backwards compatibility)
- [x] New test: route builder places HTML at custom path
- [x] New test: route builder sets correct `Post.url`
- [x] New test: route builder ignores `route_prefix` when both are set
- [x] New test: trailing slash normalization
- [x] New test: leading slash normalization
- [x] New test: route builder with `metadata.language`

Closes #17