### PR TITLE
feat: expose mork markdown parsing options

### DIFF
--- a/docs/blog-posts.md
+++ b/docs/blog-posts.md
@@ -203,6 +203,40 @@ description: A post with images
 
 If `photo.jpg` is in the same directory as `index.md`, it will be copied to the output and the relative link will resolve correctly.
 
+## Markdown parsing options
+
+Blogatto exposes markdown parsing options that control which extensions are enabled. Use `markdown.options()` to override the defaults returned by `markdown.default_options()`:
+
+```gleam
+import blogatto/config/markdown
+
+let opts = markdown.Options(
+  footnotes: True,
+  heading_ids: True,
+  tables: True,
+  tasklists: True,
+  emojis_shortcodes: True,
+  autolinks: True,
+)
+
+let md = markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.options(opts)
+```
+
+### Options reference
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `footnotes` | `True` | Enable [footnote](https://help.obsidian.md/syntax#Footnotes) parsing |
+| `heading_ids` | `False` | Add `id` attributes to all headings (enables [custom heading IDs](https://www.markdownguide.org/extended-syntax/#heading-ids)) |
+| `tables` | `True` | Enable [GFM table](https://help.obsidian.md/advanced-syntax#Tables) parsing |
+| `tasklists` | `True` | Enable [task list](https://github.github.com/gfm/#task-list-items-extension-) checkbox parsing |
+| `emojis_shortcodes` | `True` | Convert emoji shortcodes (e.g., `:smile:`) to Unicode emojis |
+| `autolinks` | `True` | Automatically convert plain URLs into clickable links |
+
+All options default to `True` except `heading_ids`, which defaults to `False`. To get the default options explicitly, use `markdown.default_options()`.
+
 ## The Post type
 
 After parsing, each markdown file produces a `Post(msg)` value with these fields:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,29 @@ config.new("https://example.com")
 |> config.markdown(md)
 ```
 
+#### Markdown parsing options
+
+The `MarkdownConfig` includes an `Options` record that controls which markdown extensions are enabled during parsing. Use `markdown.options()` to override the defaults:
+
+```gleam
+import blogatto/config/markdown
+
+let opts = markdown.Options(
+  footnotes: True,
+  heading_ids: True,
+  tables: True,
+  tasklists: True,
+  emojis_shortcodes: True,
+  autolinks: True,
+)
+
+let md = markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.options(opts)
+```
+
+See [Markdown parsing options](blog-posts#markdown-parsing-options) for details on each option.
+
 #### Markdown routing options
 
 The `MarkdownConfig` controls how blog post URLs are generated. You can use either `route_prefix` or `route_builder` (not both — `route_builder` takes precedence):

--- a/src/blogatto/config/markdown.gleam
+++ b/src/blogatto/config/markdown.gleam
@@ -24,6 +24,41 @@ import gleam/option.{type Option, None}
 import lustre/element.{type Element}
 import maud/components as maud_components
 
+/// Configuration for discovering and rendering blog articles from markdown files.
+///
+/// The `components` field specifies the components used to render each markdown
+/// AST node (headings, paragraphs, code blocks, etc.).
+/// The `paths` field lists directories to recursively search for markdown post directories.
+/// The `route_prefix` field sets the URL prefix under which blog posts are placed
+/// in the output directory (e.g., `"blog"` produces `output_dir/blog/{slug}/index.html`).
+/// The `template` field optionally overrides the default blog post page template.
+pub type MarkdownConfig(msg) {
+  MarkdownConfig(
+    /// Components used for rendering markdown AST nodes into Lustre elements.
+    components: Components(msg),
+    /// Maximum character length for auto-generated post excerpts. (default: 200)
+    excerpt_len: Int,
+    /// Markdown rendering options
+    options: Options,
+    /// Directories to recursively search for markdown post directories.
+    paths: List(String),
+    /// URL prefix for blog post output paths. When `None`, posts are written
+    /// directly under `output_dir/{slug}/index.html`. When `Some("blog")`,
+    /// posts are written to `output_dir/blog/{slug}/index.html`.
+    route_prefix: Option(String),
+    /// Function to customize the blog post URL.
+    /// It receives the `PostMetadata` and returns the URL path for that post (e.g., `"/my-post/"` or `"/it/my-post/"`).
+    /// When set `route_prefix` is IGNORED! This allows you to have full control over the post URLs,
+    /// including the ability to place them outside of the route prefix or to use a completely different URL structure.
+    /// If not provided the default builder will be used (i.e. `/{route_prefix?}/{lang}/{slug}/` or `/{route_prefix?}/{slug}/` if language is `None`).
+    route_builder: Option(fn(PostMetadata) -> String),
+    /// Optional custom template for rendering a blog post page.
+    /// Receives the parsed `Post`, and all the other posts, and returns a full page element.
+    /// When `None`, Blogatto uses a minimal default template.
+    template: Option(fn(Post(msg), List(Post(msg))) -> Element(msg)),
+  )
+}
+
 /// Text alignment for table cells.
 pub type Alignment {
   /// Left-aligned text (the default for most table cells).
@@ -73,36 +108,30 @@ pub type Components(msg) {
   )
 }
 
-/// Configuration for discovering and rendering blog articles from markdown files.
-///
-/// The `components` field specifies the components used to render each markdown
-/// AST node (headings, paragraphs, code blocks, etc.).
-/// The `paths` field lists directories to recursively search for markdown post directories.
-/// The `route_prefix` field sets the URL prefix under which blog posts are placed
-/// in the output directory (e.g., `"blog"` produces `output_dir/blog/{slug}/index.html`).
-/// The `template` field optionally overrides the default blog post page template.
-pub type MarkdownConfig(msg) {
-  MarkdownConfig(
-    /// Components used for rendering markdown AST nodes into Lustre elements.
-    components: Components(msg),
-    /// Maximum character length for auto-generated post excerpts. (default: 200)
-    excerpt_len: Int,
-    /// Directories to recursively search for markdown post directories.
-    paths: List(String),
-    /// URL prefix for blog post output paths. When `None`, posts are written
-    /// directly under `output_dir/{slug}/index.html`. When `Some("blog")`,
-    /// posts are written to `output_dir/blog/{slug}/index.html`.
-    route_prefix: Option(String),
-    /// Function to customize the blog post URL.
-    /// It receives the `PostMetadata` and returns the URL path for that post (e.g., `"/my-post/"` or `"/it/my-post/"`).
-    /// When set `route_prefix` is IGNORED! This allows you to have full control over the post URLs,
-    /// including the ability to place them outside of the route prefix or to use a completely different URL structure.
-    /// If not provided the default builder will be used (i.e. `/{route_prefix?}/{lang}/{slug}/` or `/{route_prefix?}/{slug}/` if language is `None`).
-    route_builder: Option(fn(PostMetadata) -> String),
-    /// Optional custom template for rendering a blog post page.
-    /// Receives the parsed `Post`, and all the other posts, and returns a full page element.
-    /// When `None`, Blogatto uses a minimal default template.
-    template: Option(fn(Post(msg), List(Post(msg))) -> Element(msg)),
+/// Options for markdown parsing and rendering.
+pub type Options {
+  Options(
+    /// Enable footnote parsing. (Default: True)
+    /// 
+    /// <https://help.obsidian.md/syntax#Footnotes>
+    footnotes: Bool,
+    /// Custom IDs for headings. Enabling this will add IDs to all headings regardless of whether an explicit ID was provided or not. (Default: False)
+    /// 
+    /// <https://www.markdownguide.org/extended-syntax/#heading-ids>
+    heading_ids: Bool,
+    /// Enable table parsing. (Default: True)
+    /// 
+    /// <https://help.obsidian.md/advanced-syntax#Tables>
+    tables: Bool,
+    /// Enable task list parsing. (Default: True)
+    /// 
+    /// <https://github.github.com/gfm/#task-list-items-extension->
+    tasklists: Bool,
+    /// Emoji shortcodes (e.g., `:smile:`) are converted to Unicode emojis. (Default: True)
+    emojis_shortcodes: Bool,
+    /// Automatically convert plain URLs into clickable links, even without
+    /// angle brackets or explicit link syntax. (Default: True)
+    autolinks: Bool,
   )
 }
 
@@ -112,10 +141,30 @@ pub fn default() -> MarkdownConfig(msg) {
   MarkdownConfig(
     components: default_components(),
     excerpt_len: 200,
+    options: default_options(),
     paths: [],
     route_prefix: None,
     route_builder: None,
     template: None,
+  )
+}
+
+/// Return the default markdown parsing options, with:
+/// 
+/// - Footnotes enabled
+/// - Heading IDs disabled
+/// - Table parsing enabled
+/// - Task list parsing enabled
+/// - Emoji shortcodes enabled
+/// - Extended autolinks enabled
+pub fn default_options() -> Options {
+  Options(
+    footnotes: True,
+    heading_ids: False,
+    tables: True,
+    tasklists: True,
+    emojis_shortcodes: True,
+    autolinks: True,
   )
 }
 
@@ -147,6 +196,14 @@ pub fn markdown_path(
   path: String,
 ) -> MarkdownConfig(msg) {
   MarkdownConfig(..config, paths: list.prepend(config.paths, path))
+}
+
+/// Set markdown parsing options.
+pub fn options(
+  config: MarkdownConfig(msg),
+  options: Options,
+) -> MarkdownConfig(msg) {
+  MarkdownConfig(..config, options:)
 }
 
 /// Set the URL prefix used for blog post output paths.

--- a/src/blogatto/internal/builder/blog.gleam
+++ b/src/blogatto/internal/builder/blog.gleam
@@ -25,7 +25,7 @@ import lustre/element
 import lustre/element/html
 import maud
 import maud/components as maud_components
-import mork
+import mork/document as mork_document
 import simplifile
 
 type PostInfo(msg) {
@@ -271,13 +271,10 @@ fn parse_post(
   // assets dir is the parent of the HTML file
   let assets_dir = path.parent(html_path)
   // render markdown to Lustre via Maud components
-  let options =
-    mork.configure()
-    |> mork.strip_frontmatter(True)
   let rendered_components =
     maud.render_markdown(
       markdown_file.content,
-      options,
+      mork_options(markdown_config.options),
       to_maud_components(markdown_config.components),
     )
   let excerpt =
@@ -498,4 +495,18 @@ fn from_maud_alignment(
     maud_components.Center -> markdown.Center
     maud_components.Right -> markdown.Right
   }
+}
+
+/// Convert blogatto `markdown.Options` to mork `mork_document.Options`.
+fn mork_options(options: markdown.Options) -> mork_document.Options {
+  mork_document.Options(
+    // we already parse frontmatter separately, so we can tell mork to ignore it
+    strip_frontmatter: True,
+    footnotes: options.footnotes,
+    heading_ids: options.heading_ids,
+    tables: options.tables,
+    tasklists: options.tasklists,
+    emojis: options.emojis_shortcodes,
+    autolinks: options.autolinks,
+  )
 }

--- a/test/blogatto/build_test.gleam
+++ b/test/blogatto/build_test.gleam
@@ -1065,3 +1065,89 @@ pub fn build_returns_error_for_invalid_output_dir_parent_test() {
 
   let assert Error(error.File(_)) = result
 }
+
+// --- Markdown options integration ---
+
+pub fn build_with_custom_options_renders_table_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "opts-table")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Options Table",
+        "opts-table",
+        "2024-01-15 10:00:00",
+        "Table with custom options",
+        "| A | B |\n| - | - |\n| 1 | 2 |\n",
+      ),
+    )
+
+    let md_config =
+      markdown.default()
+      |> markdown.markdown_path(blog)
+      |> markdown.options(markdown.Options(
+        footnotes: True,
+        heading_ids: False,
+        tables: True,
+        tasklists: True,
+        emojis_shortcodes: True,
+        autolinks: True,
+      ))
+
+    config.new("https://example.com")
+    |> config.output_dir(output)
+    |> config.markdown(md_config)
+    |> blogatto.build()
+    |> should.be_ok
+
+    let assert Ok(content) = simplifile.read(output <> "/opts-table/index.html")
+    content |> string.contains("<table>") |> should.be_true
+  }
+}
+
+pub fn build_with_tables_disabled_skips_table_rendering_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "no-tbl")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "No Table",
+        "no-tbl",
+        "2024-01-15 10:00:00",
+        "Table disabled",
+        "| A | B |\n| - | - |\n| 1 | 2 |\n",
+      ),
+    )
+
+    let md_config =
+      markdown.default()
+      |> markdown.markdown_path(blog)
+      |> markdown.options(markdown.Options(
+        footnotes: True,
+        heading_ids: False,
+        tables: False,
+        tasklists: True,
+        emojis_shortcodes: True,
+        autolinks: True,
+      ))
+
+    config.new("https://example.com")
+    |> config.output_dir(output)
+    |> config.markdown(md_config)
+    |> blogatto.build()
+    |> should.be_ok
+
+    let assert Ok(content) = simplifile.read(output <> "/no-tbl/index.html")
+    content |> string.contains("<table>") |> should.be_false
+  }
+}

--- a/test/blogatto/builder/blog_test.gleam
+++ b/test/blogatto/builder/blog_test.gleam
@@ -112,6 +112,22 @@ fn route_builder_config(
   |> config.markdown(md_config)
 }
 
+/// Config with custom markdown options.
+fn config_with_options(
+  output_dir: String,
+  blog_dir: String,
+  options: markdown.Options,
+) -> config.Config(msg) {
+  let md_config =
+    markdown.default()
+    |> markdown.markdown_path(blog_dir)
+    |> markdown.options(options)
+
+  config.new("https://example.com")
+  |> config.output_dir(output_dir)
+  |> config.markdown(md_config)
+}
+
 /// Config with both route_prefix and route_builder (builder should win).
 fn route_builder_with_prefix_config(
   output_dir: String,
@@ -1675,5 +1691,206 @@ pub fn build_with_route_builder_using_language_test() {
     simplifile.is_file(html_path)
     |> should.be_ok
     |> should.be_true
+  }
+}
+
+// --- Markdown options integration ---
+
+pub fn build_with_default_options_renders_table_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "table-post")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Table Post",
+        "table-post",
+        "2024-01-15 10:00:00",
+        "A post with a table",
+        "| Header 1 | Header 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |\n",
+      ),
+    )
+
+    let assert [built_post] =
+      minimal_config(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    html |> string.contains("<table>") |> should.be_true
+    html |> string.contains("<th") |> should.be_true
+    html |> string.contains("<td") |> should.be_true
+  }
+}
+
+pub fn build_with_tables_disabled_does_not_render_table_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "no-table")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "No Table",
+        "no-table",
+        "2024-01-15 10:00:00",
+        "Table markdown with tables disabled",
+        "| Header 1 | Header 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |\n",
+      ),
+    )
+
+    let opts =
+      markdown.Options(
+        footnotes: True,
+        heading_ids: False,
+        tables: False,
+        tasklists: True,
+        emojis_shortcodes: True,
+        autolinks: True,
+      )
+
+    let assert [built_post] =
+      config_with_options(output, blog, opts)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    html |> string.contains("<table>") |> should.be_false
+  }
+}
+
+pub fn build_with_heading_ids_enabled_adds_ids_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "heading-ids")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Heading IDs",
+        "heading-ids",
+        "2024-01-15 10:00:00",
+        "Post with heading IDs enabled",
+        "## My Section\n\nSome text.\n",
+      ),
+    )
+
+    let opts =
+      markdown.Options(
+        footnotes: True,
+        heading_ids: True,
+        tables: True,
+        tasklists: True,
+        emojis_shortcodes: True,
+        autolinks: True,
+      )
+
+    let assert [built_post] =
+      config_with_options(output, blog, opts)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    // heading_ids: True should produce an id attribute on h2
+    html |> string.contains("id=\"") |> should.be_true
+    html |> string.contains("<h2") |> should.be_true
+  }
+}
+
+pub fn build_with_tasklists_enabled_renders_checkboxes_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "tasklist-post")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Tasklist Post",
+        "tasklist-post",
+        "2024-01-15 10:00:00",
+        "A post with task lists",
+        "- [x] Done\n- [ ] Todo\n",
+      ),
+    )
+
+    let assert [built_post] =
+      minimal_config(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    html |> string.contains("type=\"checkbox\"") |> should.be_true
+  }
+}
+
+pub fn build_with_tasklists_disabled_does_not_render_checkboxes_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "no-tasklist")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "No Tasklist",
+        "no-tasklist",
+        "2024-01-15 10:00:00",
+        "Task list markdown with tasklists disabled",
+        "- [x] Done\n- [ ] Todo\n",
+      ),
+    )
+
+    let opts =
+      markdown.Options(
+        footnotes: True,
+        heading_ids: False,
+        tables: True,
+        tasklists: False,
+        emojis_shortcodes: True,
+        autolinks: True,
+      )
+
+    let assert [built_post] =
+      config_with_options(output, blog, opts)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    html |> string.contains("type=\"checkbox\"") |> should.be_false
   }
 }

--- a/test/blogatto/config/markdown_test.gleam
+++ b/test/blogatto/config/markdown_test.gleam
@@ -31,6 +31,30 @@ pub fn default_has_no_route_prefix_test() {
   |> should.equal(None)
 }
 
+pub fn default_options_test() {
+  let cfg = markdown.default()
+  cfg.options
+  |> should.equal(markdown.default_options())
+
+  cfg.options.autolinks
+  |> should.equal(True)
+
+  cfg.options.footnotes
+  |> should.equal(True)
+
+  cfg.options.emojis_shortcodes
+  |> should.equal(True)
+
+  cfg.options.heading_ids
+  |> should.equal(False)
+
+  cfg.options.tables
+  |> should.equal(True)
+
+  cfg.options.tasklists
+  |> should.equal(True)
+}
+
 pub fn default_components_renders_paragraph_test() {
   let comps = markdown.default_components()
   let result = comps.p([html.text("hello")])
@@ -45,6 +69,50 @@ pub fn default_components_renders_h1_test() {
   result
   |> element.to_string
   |> should.equal("<h1 id=\"title\">Title</h1>")
+}
+
+// --- excerpt_len ---
+
+pub fn excerpt_len_overrides_default_test() {
+  let cfg =
+    markdown.default()
+    |> markdown.excerpt_len(100)
+
+  cfg.excerpt_len
+  |> should.equal(100)
+}
+
+// --- template ---
+
+pub fn template_overrides_default_test() {
+  let tmpl = fn(_post, _all_posts) { html.div([], [html.text("custom")]) }
+  let cfg =
+    markdown.default()
+    |> markdown.template(tmpl)
+
+  cfg.template
+  |> should.be_some
+}
+
+// --- options ---
+
+pub fn options_overrides_defaults_test() {
+  let custom_options =
+    markdown.Options(
+      autolinks: False,
+      footnotes: False,
+      emojis_shortcodes: False,
+      heading_ids: True,
+      tables: False,
+      tasklists: False,
+    )
+
+  let cfg =
+    markdown.default()
+    |> markdown.options(custom_options)
+
+  cfg.options
+  |> should.equal(custom_options)
 }
 
 //  --- route_prefix ---


### PR DESCRIPTION
## Summary

- Add `Options` type to `MarkdownConfig` exposing mork markdown extension toggles (tables, footnotes, heading IDs, task lists, emoji shortcodes, autolinks)
- Add `markdown.options()` setter and `markdown.default_options()` constructor
- Update blog builder to use `mork_document.Options` directly instead of the deprecated `mork.configure()` builder API
- Add unit tests for config defaults/setters and integration tests verifying options affect rendering output (tables enabled/disabled, heading IDs, task lists)
- Document parsing options in `docs/blog-posts.md` and `docs/configuration.md`

Closes #21

## Test plan

- [x] Unit tests for `default_options()`, `options()` setter, and all default field values
- [x] Integration tests in `blog_test.gleam`: tables enabled/disabled, heading IDs, task lists enabled/disabled
- [x] End-to-end tests in `build_test.gleam`: full pipeline with custom options
- [x] All 380 tests pass