### PR TITLE
feat!: auto generate `slug` if missing from frontmatter

### DIFF
--- a/docs/blog-posts.md
+++ b/docs/blog-posts.md
@@ -10,16 +10,16 @@ Blogatto discovers blog posts from markdown files with YAML frontmatter. This gu
 
 ## Directory-per-post convention
 
-Each blog post lives in its own directory. The directory name becomes the post's **slug** (URL-friendly identifier):
+Each blog post lives in its own directory:
 
 ```text
 blog/
-  my-first-post/         # slug: "my-first-post"
+  my-first-post/
     index.md             # Default language
     index-it.md          # Italian variant
     index-fr.md          # French variant
     cover.jpg            # Asset copied to output
-  another-post/          # slug: "another-post"
+  another-post/
     index.md
     diagram.png
 ```
@@ -33,7 +33,6 @@ Each markdown file must start with a YAML frontmatter block:
 ```markdown
 ---
 title: My First Post
-slug: my-first-post
 date: 2025-01-15 00:00:00
 description: A short description of the post
 featured_image: /images/hero.jpg
@@ -47,7 +46,6 @@ Your markdown content here...
 | Field | Format | Description |
 |-------|--------|-------------|
 | `title` | String | The post title |
-| `slug` | String | URL-friendly identifier for the post |
 | `date` | `YYYY-MM-DD HH:MM:SS` | Publication date (UTC) |
 | `description` | String | A short description or excerpt |
 
@@ -55,6 +53,7 @@ Your markdown content here...
 
 | Field | Format | Description |
 |-------|--------|-------------|
+| `slug` | String | URL-friendly identifier for the post. If omitted, auto-generated from the title (e.g., `"My First Post"` becomes `"my-first-post"`) |
 | `featured_image` | String | URL or path to a featured image |
 
 ### Extra fields
@@ -64,7 +63,6 @@ Any frontmatter keys beyond the required and optional fields are collected in `P
 ```markdown
 ---
 title: My Post
-slug: my-post
 date: 2025-01-15 00:00:00
 description: A post about Gleam
 author: Jane Doe
@@ -162,7 +160,7 @@ The `PostMetadata` type contains all frontmatter-derived fields available at rou
 | Field | Type | Description |
 |-------|------|-------------|
 | `title` | `String` | From frontmatter |
-| `slug` | `String` | From frontmatter |
+| `slug` | `String` | From frontmatter, or auto-generated from title |
 | `date` | `Timestamp` | From frontmatter |
 | `description` | `String` | From frontmatter |
 | `language` | `Option(String)` | `None` for default, `Some("it")` for variants |
@@ -193,7 +191,6 @@ Non-markdown files in a post directory (images, PDFs, etc.) are automatically co
 ```markdown
 ---
 title: My Post
-slug: my-post
 date: 2025-01-15 00:00:00
 description: A post with images
 ---
@@ -244,7 +241,7 @@ After parsing, each markdown file produces a `Post(msg)` value with these fields
 | Field | Type | Description |
 |-------|------|-------------|
 | `title` | `String` | From frontmatter |
-| `slug` | `String` | From frontmatter |
+| `slug` | `String` | From frontmatter, or auto-generated from title |
 | `url` | `String` | Absolute URL (e.g., `"https://example.com/blog/my-post"`) |
 | `date` | `Timestamp` | From frontmatter |
 | `description` | `String` | From frontmatter |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -15,7 +15,7 @@ All Blogatto build functions return `Result(Nil, BlogattoError)`. The library ne
 | `DevServer(String)` | Error message | An error occurred in the development server (e.g. file watching, live reload) |
 | `File(FileError)` | `simplifile.FileError` | File system error (reading, writing, deleting files or directories) |
 | `FrontmatterMissing` | — | A markdown file has no frontmatter block |
-| `FrontmatterMissingField(String)` | Field name | A required frontmatter field (`title`, `date`, `slug`, or `description`) is missing |
+| `FrontmatterMissingField(String)` | Field name | A required frontmatter field (`title`, `date`, or `description`) is missing |
 | `FrontmatterInvalidDate(String)` | The date string | The `date` field could not be parsed as `YYYY-MM-DD HH:MM:SS` |
 | `FrontmatterInvalidLine(String)` | The line content | A frontmatter line could not be parsed as a `key: value` pair |
 | `InvalidUri(String)` | The invalid URI string | A URI could not be parsed during URL resolution |

--- a/docs/example.md
+++ b/docs/example.md
@@ -234,14 +234,13 @@ Key points:
 
 ## Blog posts
 
-Each blog post lives in its own directory under `blog/`. The directory name becomes the slug.
+Each blog post lives in its own directory under `blog/`.
 
 ### hello-world/index.md
 
 ```markdown
 ---
 title: Hello World
-slug: hello-world
 date: 2025-01-15 00:00:00
 description: Welcome to my new blog built with Blogatto
 ---
@@ -261,7 +260,6 @@ Blogatto is a framework for building static blogs with Lustre and Markdown...
 ```markdown
 ---
 title: Getting Started with Blogatto
-slug: getting-started
 date: 2025-01-20 00:00:00
 description: Learn how to set up your first static blog with Blogatto
 ---
@@ -271,7 +269,7 @@ description: Learn how to set up your first static blog with Blogatto
 Setting up a blog with Blogatto is straightforward...
 ```
 
-Required frontmatter fields are `title`, `slug`, `date`, and `description`. Any additional fields (e.g. `author`, `tags`) are collected into the post's `extras` dictionary.
+Required frontmatter fields are `title`, `date`, and `description`. The `slug` field is optional — if omitted, it is auto-generated from the title. Any additional fields (e.g. `author`, `tags`) are collected into the post's `extras` dictionary.
 
 ## Generated output
 

--- a/examples/simple_blog/blog/hello-world/index.md
+++ b/examples/simple_blog/blog/hello-world/index.md
@@ -1,6 +1,5 @@
 ---
 title: Hello World
-slug: hello-world
 date: 2025-01-15 00:00:00
 description: Welcome to my new blog built with Blogatto
 ---

--- a/examples/simple_blog/manifest.toml
+++ b/examples/simple_blog/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "blogatto", version = "3.0.0", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "webls"], source = "local", path = "../.." },
+  { name = "blogatto", version = "4.0.0", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "str", "webls"], source = "local", path = "../.." },
   { name = "casefold", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "casefold", source = "hex", outer_checksum = "F09530B6F771BB7B0BCACD3014089C20DFDA31775BA4793266C3814607C0A468" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -15,7 +15,7 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
-  { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
+  { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
@@ -30,9 +30,11 @@ packages = [
   { name = "maud", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "mork"], otp_app = "maud", source = "hex", outer_checksum = "3CD10B85CC436DD338E1AFAAF5C1CEA2B1D789689205A48374E9126E052F04F1" },
   { name = "mist", version = "5.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7CED4B2D81FD547ADB093D97B9928B9419A7F58B8562A30A6CC17A252B31AD05" },
   { name = "mork", version = "1.11.1", build_tools = ["gleam"], requirements = ["casefold", "gleam_regexp", "gleam_stdlib", "splitter"], otp_app = "mork", source = "hex", outer_checksum = "2DB4900FCCBB2CF9AB8C8438620FE00FC38CC6D340D52275D10769A4B43B3E5B" },
-  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
+  { name = "odysseus", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "odysseus", source = "hex", outer_checksum = "6A97DA1075BDDEA8B60F47B1DFFAD49309FA27E73843F13A0AF32EA7087BA11C" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
-  { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
+  { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
+  { name = "telemetry", version = "1.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "2172E05A27531D3D31DD9782841065C50DD5C3C7699D95266B2EDD54C2DAFA1C" },
   { name = "webls", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "webls", source = "hex", outer_checksum = "40317445399BFBBDCE8D5976C84ACD92319D4A6F1500A926F19AFCC9ED6639F1" },
 ]
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "blogatto"
-version = "3.0.0"
+version = "4.0.0"
 description = "A Gleam framework for building static blogs with Lustre and Markdown. Generates HTML pages, RSS feeds, sitemaps, and robots.txt from markdown files with frontmatter, with multilingual support."
 repository = { type = "github", user = "veeso", repo = "blogatto" }
 licenses = ["MIT"]
@@ -26,6 +26,7 @@ maud = ">= 1.0.0 and < 2.0.0"
 mist = ">= 5.0.4 and < 6.0.0"
 mork = ">= 1.11.1 and < 2.0.0"
 simplifile = ">= 2.3.2 and < 3.0.0"
+str = ">= 2.0.1 and < 3.0.0"
 webls = ">= 1.6.1 and < 2.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -30,8 +30,10 @@ packages = [
   { name = "maud", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "mork"], otp_app = "maud", source = "hex", outer_checksum = "3CD10B85CC436DD338E1AFAAF5C1CEA2B1D789689205A48374E9126E052F04F1" },
   { name = "mist", version = "5.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7CED4B2D81FD547ADB093D97B9928B9419A7F58B8562A30A6CC17A252B31AD05" },
   { name = "mork", version = "1.11.1", build_tools = ["gleam"], requirements = ["casefold", "gleam_regexp", "gleam_stdlib", "splitter"], otp_app = "mork", source = "hex", outer_checksum = "2DB4900FCCBB2CF9AB8C8438620FE00FC38CC6D340D52275D10769A4B43B3E5B" },
+  { name = "odysseus", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "odysseus", source = "hex", outer_checksum = "6A97DA1075BDDEA8B60F47B1DFFAD49309FA27E73843F13A0AF32EA7087BA11C" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "temporary", version = "1.0.0", build_tools = ["gleam"], requirements = ["envoy", "exception", "filepath", "gleam_crypto", "gleam_stdlib", "simplifile"], otp_app = "temporary", source = "hex", outer_checksum = "51C0FEF4D72CE7CA507BD188B21C1F00695B3D5B09D7DFE38240BFD3A8E1E9B3" },
   { name = "webls", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "webls", source = "hex", outer_checksum = "40317445399BFBBDCE8D5976C84ACD92319D4A6F1500A926F19AFCC9ED6639F1" },
@@ -54,5 +56,6 @@ maud = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 5.0.4 and < 6.0.0" }
 mork = { version = ">= 1.11.1 and < 2.0.0" }
 simplifile = { version = ">= 2.3.2 and < 3.0.0" }
+str = { version = ">= 2.0.1 and < 3.0.0" }
 temporary = { version = ">= 1.0.0 and < 2.0.0" }
 webls = { version = ">= 1.6.1 and < 2.0.0" }

--- a/src/blogatto/internal/builder/blog.gleam
+++ b/src/blogatto/internal/builder/blog.gleam
@@ -27,6 +27,7 @@ import maud
 import maud/components as maud_components
 import mork/document as mork_document
 import simplifile
+import str
 
 type PostInfo(msg) {
   PostInfo(
@@ -392,13 +393,14 @@ fn post_url(site_url: String, path: String) -> String {
   base <> path
 }
 
-/// Helper function to parse the frontmatter of a markdown file and extract the required fields (title, slug, date, description) along with any additional fields.
+/// Helper function to parse the frontmatter of a markdown file and extract the required fields (title, date, description) along with any additional fields.
+/// 
+/// Slug is either parsed from the frontmatter or generated from the title using `slugify`. Date is parsed into a `timestamp.Timestamp` value.
 fn parse_frontmatter(
   content: String,
 ) -> Result(Frontmatter, error.BlogattoError) {
   use frontmatter <- result.try(frontmatter.parse_content(content))
   use title <- result.try(get_frontmatter_required_field(frontmatter, "title"))
-  use slug <- result.try(get_frontmatter_required_field(frontmatter, "slug"))
   use date <- result.try(get_frontmatter_required_field(frontmatter, "date"))
   use description <- result.try(get_frontmatter_required_field(
     frontmatter,
@@ -407,6 +409,10 @@ fn parse_frontmatter(
   let featured_image =
     get_frontmatter_optional_field(frontmatter, "featured_image")
   use date <- result.try(date.parse(date))
+  let slug =
+    frontmatter
+    |> get_frontmatter_optional_field("slug")
+    |> option.unwrap(or: str.slugify(title))
 
   // get extras by filtering out the known fields from the frontmatter dictionary
   let extras =

--- a/src/blogatto/post.gleam
+++ b/src/blogatto/post.gleam
@@ -1,8 +1,9 @@
 //// Blog post type representing a parsed markdown article.
 ////
 //// A `Post` is produced by the build pipeline after parsing a markdown file
-//// with frontmatter metadata. The `slug` is derived from the post's directory name,
-//// and the `language` is determined by the filename convention:
+//// with frontmatter metadata. The `slug` is either taken from the frontmatter
+//// or auto-generated from the title via slugification.
+//// The `language` is determined by the filename convention:
 //// `index.md` for the default language (`None`) or `index-{lang}.md` for a specific language.
 ////
 //// ## Example
@@ -28,12 +29,13 @@ import lustre/element.{type Element}
 /// A parsed blog post with rendered markdown contents.
 ///
 /// Required frontmatter fields are `title`, `date`, and `description`.
+/// The `slug` field is optional; if omitted, it is auto-generated from the title.
 /// Any additional frontmatter keys are collected in `extras`.
 pub type Post(msg) {
   Post(
     /// The post title, extracted from the `title` frontmatter field.
     title: String,
-    /// URL-friendly identifier derived from the post's directory name.
+    /// URL-friendly identifier from frontmatter, or auto-generated from the title.
     slug: String,
     /// The absolute URL for this post (e.g., `"https://example.com/blog/my-post/"`).
     /// Constructed from the site URL, optional route prefix, optional language,
@@ -62,7 +64,7 @@ pub type PostMetadata {
   PostMetadata(
     /// The post title, extracted from the `title` frontmatter field.
     title: String,
-    /// URL-friendly identifier derived from the post's directory name.
+    /// URL-friendly identifier from frontmatter, or auto-generated from the title.
     slug: String,
     /// Publication date extracted from the `date` frontmatter field.
     date: timestamp.Timestamp,

--- a/test/blogatto/builder/blog_test.gleam
+++ b/test/blogatto/builder/blog_test.gleam
@@ -36,6 +36,22 @@ fn markdown_content(
   <> body
 }
 
+fn markdown_content_without_slug(
+  title: String,
+  date: String,
+  description: String,
+  body: String,
+) -> String {
+  "---\ntitle: "
+  <> title
+  <> "\ndate: "
+  <> date
+  <> "\ndescription: "
+  <> description
+  <> "\n---\n"
+  <> body
+}
+
 fn sample_markdown() -> String {
   markdown_content(
     "Hello World",
@@ -1012,7 +1028,7 @@ pub fn build_returns_error_for_missing_title_test() {
   }
 }
 
-pub fn build_returns_error_for_missing_slug_test() {
+pub fn build_auto_generates_slug_from_title_when_missing_test() {
   let assert Ok(_) = {
     use dir <- temporary.create(temporary.directory())
     use blog <- temporary.create(temporary.directory())
@@ -1021,17 +1037,47 @@ pub fn build_returns_error_for_missing_slug_test() {
     write_markdown(
       post_dir,
       "index.md",
-      "---\ntitle: No Slug\ndate: 2024-01-01 00:00:00\ndescription: missing slug\n---\n# Body\n",
+      markdown_content_without_slug(
+        "My Amazing Post",
+        "2024-01-01 00:00:00",
+        "a post without slug",
+        "# Body\n",
+      ),
     )
 
-    let result =
+    let assert [post] =
       minimal_config(dir, blog)
       |> blog_builder.build()
+      |> should.be_ok
 
-    result |> should.be_error
+    post.slug |> should.equal("my-amazing-post")
+  }
+}
 
-    let assert Error(error.FrontmatterMissingField("slug")) = result
-    Nil
+pub fn build_uses_explicit_slug_over_auto_generated_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+
+    let post_dir = create_post_dir(blog, "custom-slug")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "My Amazing Post",
+        "custom-slug",
+        "2024-01-01 00:00:00",
+        "a post with explicit slug",
+        "# Body\n",
+      ),
+    )
+
+    let assert [post] =
+      minimal_config(dir, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    post.slug |> should.equal("custom-slug")
   }
 }
 


### PR DESCRIPTION
`slug` is no more a required field in the frontmatter. If missing it is automatically generated by slugifying the post title

closes #25
BREAKING CHANGE: `slug` is no more required. User has nothing to change to their code though.
