### PR TITLE
feat: build-time syntax highlighting via smalto

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Package Version](https://img.shields.io/hexpm/v/blogatto)](https://hex.pm/packages/blogatto)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/blogatto/)
 [![conventional-commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
-[![target-erlang](https://img.shields.io/badge/target-erlang-b83998)](https://www.erlang.org/)
+[![Erlang Compatible](https://img.shields.io/badge/target-erlang-b83998)](https://www.erlang.org/)
 [![test](https://github.com/veeso/blogatto/actions/workflows/test.yml/badge.svg)](https://github.com/veeso/blogatto/actions/workflows/test.yml)
 
 A Gleam framework for building static blogs with [**Lustre**](https://hexdocs.pm/lustre/) and Markdown.
@@ -22,6 +22,7 @@ Blogatto generates your entire static site from a single configuration: blog pos
 - Robots.txt generation
 - Static asset copying
 - Custom Maud components for markdown rendering
+- Build-time syntax highlighting for code blocks via [Smalto](https://hexdocs.pm/smalto/)
 - Configurable blog post templates
 - Dev server with file watching, auto-rebuild, and live reload
 
@@ -119,7 +120,7 @@ fn home_view(posts: List(Post(Nil))) -> Element(Nil) {
 
 Running `gleam run` will generate the `dist` directory with the following structure:
 
-```
+```txt
 dist/
 ├── blog/
 │   └── my-post/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,21 @@ let md = markdown.default()
 
 See [Markdown parsing options](blog-posts#markdown-parsing-options) for details on each option.
 
+#### Syntax highlighting
+
+Enable build-time syntax highlighting for fenced code blocks:
+
+```gleam
+import blogatto/config/markdown
+import blogatto/config/markdown/code
+
+let md = markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.syntax_highlighting(code.default())
+```
+
+See [Syntax highlighting](syntax-highlighting) for the full guide on supported languages, styling, and customization.
+
 #### Markdown routing options
 
 The `MarkdownConfig` controls how blog post URLs are generated. You can use either `route_prefix` or `route_builder` (not both — `route_builder` takes precedence):

--- a/docs/dev-server.md
+++ b/docs/dev-server.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Dev server
-nav_order: 10
+nav_order: 11
 ---
 
 # Dev server

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Error handling
-nav_order: 11
+nav_order: 12
 ---
 
 # Error handling

--- a/docs/example.md
+++ b/docs/example.md
@@ -50,16 +50,31 @@ The build configuration lives in `src/simple_blog/blog.gleam` as a shared module
 The markdown config tells Blogatto where to find posts and how to render them:
 
 ```gleam
+let syntax_config = code.default()
+
 let md_config =
   markdown.default()
   |> markdown.markdown_path("./blog")
   |> markdown.route_prefix("blog")
   |> markdown.template(blog_post_template)
+  |> markdown.syntax_highlighting(syntax_config)
+  |> markdown.pre(fn(children) {
+    html.pre([attribute.class("code-block")], children)
+  })
+  |> markdown.code(fn(language, children) {
+    let lang_class = case language {
+      option.Some(lang) -> "language-" <> lang
+      option.None -> ""
+    }
+    html.code([attribute.class(lang_class)], children)
+  })
 ```
 
 - `markdown_path("./blog")` — scan the `blog/` directory for post directories
 - `route_prefix("blog")` — output posts under `/blog/{slug}/`
 - `template(blog_post_template)` — wrap each post in a custom HTML page layout
+- `syntax_highlighting(syntax_config)` — enable build-time syntax highlighting for code blocks (see [Syntax highlighting](syntax-highlighting))
+- `pre` and `code` — add CSS classes to code block wrappers for styling
 
 ### RSS feed
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,4 +158,5 @@ See the [simple_blog example](https://github.com/veeso/blogatto/tree/main/exampl
 
 - [Blog posts](blog-posts) — learn about frontmatter, multilingual support, and post assets
 - [Configuration](configuration) — explore all configuration options
+- [Syntax highlighting](syntax-highlighting) — enable build-time code block highlighting
 - [Static pages](static-pages) — add more pages and use post data in views

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Blogatto generates your entire static site from a single configuration: blog pos
 - **Sitemap XML** — automatic sitemap generation covering static pages and blog posts
 - **Robots.txt** — configurable crawl policies with sitemap reference
 - **Custom markdown rendering** — override any markdown element's HTML output via Maud components
+- **Build-time syntax highlighting** — highlight code blocks at build time via [Smalto](https://hexdocs.pm/smalto/), with 28 built-in languages and customizable token rendering
 - **Custom post routing** — control blog post URLs with a route builder function for date-based, category-based, or any custom URL scheme
 - **Blog post templates** — full control over the page layout wrapping each blog post
 - **Static asset copying** — copy CSS, images, and other assets into the output directory
@@ -54,6 +55,7 @@ The output is a fully static site ready to deploy to any static hosting provider
 | [Blog posts](blog-posts) | Directory structure, frontmatter, multilingual support |
 | [Configuration](configuration) | Full configuration reference |
 | [Markdown components](markdown-components) | Customizing markdown rendering |
+| [Syntax highlighting](syntax-highlighting) | Build-time code block highlighting with Smalto |
 | [Static pages](static-pages) | Routes, view functions, and using post data |
 | [RSS feeds](rss-feeds) | Feed configuration, filtering, and serialization |
 | [Sitemap and robots.txt](sitemap-and-robots) | Sitemap and crawler configuration |

--- a/docs/markdown-components.md
+++ b/docs/markdown-components.md
@@ -119,7 +119,9 @@ markdown.a(fn(href, title, children) {
 
 The `code` component receives `Some("gleam")` for fenced code blocks with a language tag, or `None` for inline code.
 
-Example — add language class for syntax highlighting:
+> **Tip:** Blogatto supports build-time syntax highlighting via Smalto, which automatically tokenizes code blocks and renders styled `<span>` elements. When syntax highlighting is enabled, the `code` component receives pre-highlighted children. See [Syntax highlighting](syntax-highlighting) for the full guide.
+
+Example — add language class to code blocks:
 
 ```gleam
 import gleam/option.{None, Some}

--- a/docs/rss-feeds.md
+++ b/docs/rss-feeds.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: RSS feeds
-nav_order: 8
+nav_order: 9
 ---
 
 # RSS feeds

--- a/docs/sitemap-and-robots.md
+++ b/docs/sitemap-and-robots.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Sitemap and robots.txt
-nav_order: 9
+nav_order: 10
 ---
 
 # Sitemap and robots.txt

--- a/docs/static-pages.md
+++ b/docs/static-pages.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Static pages
-nav_order: 7
+nav_order: 8
 ---
 
 # Static pages

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,0 +1,249 @@
+---
+layout: default
+title: Syntax highlighting
+nav_order: 7
+---
+
+# Syntax highlighting
+
+Blogatto supports build-time syntax highlighting for code blocks in your markdown files via [Smalto](https://hexdocs.pm/smalto/). When enabled, fenced code blocks with a language tag (e.g., `` ```gleam ``) are highlighted at build time, producing styled HTML with no client-side JavaScript required.
+
+## Enabling syntax highlighting
+
+Syntax highlighting is disabled by default. Enable it by passing a `SyntaxHighlightingConfig` to the markdown configuration:
+
+```gleam
+import blogatto/config/markdown
+import blogatto/config/markdown/code
+
+let md =
+  markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.syntax_highlighting(code.default())
+```
+
+`code.default()` includes grammars for 28 languages out of the box.
+
+## Supported languages
+
+The default configuration supports the following languages (with aliases):
+
+| Language | Aliases |
+|----------|---------|
+| Bash | `bash`, `sh`, `shell` |
+| C | `c` |
+| C++ | `cpp` |
+| CSS | `css` |
+| Dart | `dart` |
+| Dockerfile | `dockerfile` |
+| Elixir | `elixir` |
+| Erlang | `erlang` |
+| Gleam | `gleam` |
+| Go | `go`, `golang` |
+| Haskell | `haskell`, `hs` |
+| HTML | `html` |
+| Java | `java` |
+| JavaScript | `javascript`, `js` |
+| JSON | `json` |
+| Kotlin | `kotlin`, `kt` |
+| Lua | `lua` |
+| Markdown | `markdown`, `md` |
+| PHP | `php` |
+| Python | `python`, `py` |
+| Ruby | `ruby`, `rb` |
+| Rust | `rust`, `rs` |
+| Scala | `scala` |
+| SQL | `sql` |
+| Swift | `swift` |
+| TOML | `toml` |
+| TypeScript | `typescript`, `ts` |
+| XML | `xml` |
+| YAML | `yaml`, `yml` |
+| Zig | `zig` |
+
+## Adding custom languages
+
+If a language you need is not in the default set, add it with `code.add_language()`:
+
+```gleam
+import blogatto/config/markdown/code
+import smalto/languages/ocaml
+
+let syntax_config =
+  code.default()
+  |> code.add_language(ocaml.grammar, ["ocaml", "ml"])
+```
+
+The second argument is a list of names that will match the language tag in fenced code blocks.
+
+## Styling highlighted code
+
+Smalto renders each token as a `<span>` with a CSS class corresponding to the token type. By default, the classes are:
+
+| Token type | CSS class |
+|------------|-----------|
+| Keyword | `smalto-keyword` |
+| String | `smalto-string` |
+| Number | `smalto-number` |
+| Comment | `smalto-comment` |
+| Function | `smalto-function` |
+| Operator | `smalto-operator` |
+| Punctuation | `smalto-punctuation` |
+| Type | `smalto-type` |
+| Module | `smalto-module` |
+| Variable | `smalto-variable` |
+| Constant | `smalto-constant` |
+| Builtin | `smalto-builtin` |
+| Tag | `smalto-tag` |
+| Attribute | `smalto-attribute` |
+| Selector | `smalto-selector` |
+| Property | `smalto-property` |
+| Regex | `smalto-regex` |
+
+To style your code blocks, add CSS rules for these classes. Here is a minimal dark theme example:
+
+```css
+pre.code-block {
+  background: #1e1e2e;
+  color: #cdd6f4;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+.smalto-keyword { color: #cba6f7; }
+.smalto-string { color: #a6e3a1; }
+.smalto-number { color: #fab387; }
+.smalto-comment { color: #6c7086; font-style: italic; }
+.smalto-function { color: #89b4fa; }
+.smalto-operator { color: #89dceb; }
+.smalto-punctuation { color: #cdd6f4; }
+.smalto-type { color: #f9e2af; }
+.smalto-module { color: #f9e2af; }
+.smalto-variable { color: #cdd6f4; }
+.smalto-constant { color: #fab387; }
+.smalto-builtin { color: #f38ba8; }
+.smalto-tag { color: #f38ba8; }
+.smalto-attribute { color: #f9e2af; }
+.smalto-selector { color: #a6e3a1; }
+.smalto-property { color: #89b4fa; }
+.smalto-regex { color: #f5c2e7; }
+```
+
+## Custom token rendering
+
+If CSS classes are not enough, you can override how each token type is rendered using the setter functions on `SyntaxHighlightingConfig`. Each setter takes a function that receives the token text and returns a Lustre element:
+
+```gleam
+import blogatto/config/markdown/code
+import lustre/attribute
+import lustre/element
+import lustre/element/html
+
+let syntax_config =
+  code.default()
+  |> code.keyword(fn(text) {
+    html.span(
+      [attribute.style([#("color", "#cba6f7"), #("font-weight", "bold")])],
+      [element.text(text)],
+    )
+  })
+  |> code.comment(fn(text) {
+    html.span(
+      [attribute.style([#("color", "#6c7086"), #("font-style", "italic")])],
+      [element.text(text)],
+    )
+  })
+```
+
+Available token setters: `keyword`, `string`, `number`, `comment`, `function`, `operator`, `punctuation`, `type_`, `module`, `variable`, `constant`, `builtin`, `tag`, `attribute`, `selector`, `property`, `regex`.
+
+There is also a `custom` setter for custom token types emitted by some grammars. It receives both the custom type name and the token text:
+
+```gleam
+code.custom(fn(type_name, text) {
+  html.span(
+    [attribute.class("smalto-custom-" <> type_name)],
+    [element.text(text)],
+  )
+})
+```
+
+## Using with `smalto_config`
+
+For full control over the underlying Smalto rendering, use `code.smalto_config()` to pass a custom `smalto_lustre.Config` directly:
+
+```gleam
+import blogatto/config/markdown/code
+import smalto/lustre as smalto_lustre
+
+let smalto_cfg = smalto_lustre.default_config()
+  // ... customize via smalto_lustre API ...
+
+let syntax_config =
+  code.default()
+  |> code.smalto_config(smalto_cfg)
+```
+
+## Customizing the code block wrapper
+
+Syntax highlighting controls the _contents_ of code blocks. To customize the wrapping `<pre>` and `<code>` elements, use the markdown component setters:
+
+```gleam
+import blogatto/config/markdown
+import blogatto/config/markdown/code
+import gleam/option
+
+let md =
+  markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.syntax_highlighting(code.default())
+  |> markdown.pre(fn(children) {
+    html.pre([attribute.class("code-block")], children)
+  })
+  |> markdown.code(fn(language, children) {
+    let lang_class = case language {
+      option.Some(lang) -> "language-" <> lang
+      option.None -> ""
+    }
+    html.code([attribute.class(lang_class)], children)
+  })
+```
+
+## Complete example
+
+Putting it all together — a markdown config with syntax highlighting, custom wrapper classes, and a custom keyword style:
+
+```gleam
+import blogatto/config/markdown
+import blogatto/config/markdown/code
+import gleam/option
+import lustre/attribute
+import lustre/element
+import lustre/element/html
+
+let syntax_config =
+  code.default()
+  |> code.keyword(fn(text) {
+    html.span(
+      [attribute.class("token-keyword")],
+      [element.text(text)],
+    )
+  })
+
+let md =
+  markdown.default()
+  |> markdown.markdown_path("./blog")
+  |> markdown.route_prefix("blog")
+  |> markdown.syntax_highlighting(syntax_config)
+  |> markdown.pre(fn(children) {
+    html.pre([attribute.class("code-block")], children)
+  })
+  |> markdown.code(fn(language, children) {
+    let lang_class = case language {
+      option.Some(lang) -> "language-" <> lang
+      option.None -> ""
+    }
+    html.code([attribute.class(lang_class)], children)
+  })
+```

--- a/examples/simple_blog/blog/code-showcase/index.md
+++ b/examples/simple_blog/blog/code-showcase/index.md
@@ -1,0 +1,271 @@
+---
+title: Syntax Highlighting Showcase
+slug: code-showcase
+date: 2025-01-25 00:00:00
+description: A showcase of syntax highlighting across different programming languages
+---
+
+# Syntax Highlighting Showcase
+
+Blogatto supports build-time syntax highlighting powered by [smalto](https://github.com/veeso/smalto). Code blocks are tokenized and rendered as styled HTML elements at build time, so no JavaScript is required on the client.
+
+## Gleam
+
+```gleam
+import gleam/io
+import gleam/list
+import gleam/string
+
+pub type Animal {
+  Cat(name: String, lives: Int)
+  Dog(name: String, is_good: Bool)
+}
+
+pub fn greet(animal: Animal) -> String {
+  case animal {
+    Cat(name, ..) -> "Hello, " <> name <> "!"
+    Dog(name, is_good) ->
+      case is_good {
+        True -> name <> " is a good dog!"
+        False -> name <> " is still a good dog!"
+      }
+  }
+}
+
+pub fn main() {
+  let pets = [Cat("Whiskers", 9), Dog("Rex", True)]
+  pets
+  |> list.map(greet)
+  |> list.each(io.println)
+}
+```
+
+## Rust
+
+```rust
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+struct Config {
+    name: String,
+    values: HashMap<String, i64>,
+}
+
+impl Config {
+    fn new(name: &str) -> Self {
+        Config {
+            name: name.to_string(),
+            values: HashMap::new(),
+        }
+    }
+
+    fn set(&mut self, key: &str, value: i64) {
+        self.values.insert(key.to_string(), value);
+    }
+}
+
+fn main() {
+    let mut config = Config::new("example");
+    config.set("timeout", 30);
+    config.set("retries", 3);
+    println!("{:?}", config);
+}
+```
+
+## Python
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Task:
+    title: str
+    done: bool = False
+    priority: Optional[int] = None
+
+def filter_pending(tasks: list[Task]) -> list[Task]:
+    """Return only tasks that are not yet done."""
+    return [t for t in tasks if not t.done]
+
+if __name__ == "__main__":
+    tasks = [
+        Task("Write docs", priority=1),
+        Task("Fix bug #42", done=True),
+        Task("Add tests", priority=2),
+    ]
+    for task in filter_pending(tasks):
+        print(f"TODO: {task.title}")
+```
+
+## TypeScript
+
+```typescript
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: "admin" | "user" | "guest";
+}
+
+async function fetchUsers(endpoint: string): Promise<User[]> {
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+const formatUser = (user: User): string =>
+  `${user.name} <${user.email}> [${user.role}]`;
+
+const main = async () => {
+  const users = await fetchUsers("/api/users");
+  users
+    .filter((u) => u.role !== "guest")
+    .map(formatUser)
+    .forEach(console.log);
+};
+```
+
+## Go
+
+```go
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type Result struct {
+	Word  string
+	Count int
+}
+
+func countWords(text string) map[string]int {
+	counts := make(map[string]int)
+	for _, word := range strings.Fields(text) {
+		counts[strings.ToLower(word)]++
+	}
+	return counts
+}
+
+func main() {
+	texts := []string{
+		"hello world hello",
+		"world of code",
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan Result)
+
+	for _, text := range texts {
+		wg.Add(1)
+		go func(t string) {
+			defer wg.Done()
+			for word, count := range countWords(t) {
+				results <- Result{Word: word, Count: count}
+			}
+		}(text)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for r := range results {
+		fmt.Printf("%s: %d\n", r.Word, r.Count)
+	}
+}
+```
+
+## HTML
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Example Page</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/">Home</a>
+      <a href="/about">About</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Welcome</h1>
+    <p>This is an <strong>example</strong> page.</p>
+  </main>
+</body>
+</html>
+```
+
+## SQL
+
+```sql
+SELECT
+    u.name,
+    u.email,
+    COUNT(o.id) AS order_count,
+    COALESCE(SUM(o.total), 0) AS total_spent
+FROM users u
+LEFT JOIN orders o ON o.user_id = u.id
+WHERE u.created_at >= '2024-01-01'
+GROUP BY u.id, u.name, u.email
+HAVING COUNT(o.id) > 0
+ORDER BY total_spent DESC
+LIMIT 10;
+```
+
+## YAML
+
+```yaml
+name: deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: gleam build
+      - name: Test
+        run: gleam test
+```
+
+## Bash
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+readonly LOG_FILE="/var/log/deploy.log"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+deploy() {
+    local version="$1"
+    log "Deploying version ${version}..."
+
+    if [ -d "./dist" ]; then
+        rm -rf ./dist
+    fi
+
+    gleam build && gleam run
+    log "Deploy complete."
+}
+
+deploy "${1:-latest}"
+```

--- a/examples/simple_blog/gleam.toml
+++ b/examples/simple_blog/gleam.toml
@@ -7,6 +7,9 @@ gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 lustre = ">= 5.6.0 and < 6.0.0"
 gleam_time = ">= 1.7.0 and < 2.0.0"
 blogatto = { path = "../../" }
+smalto = ">= 2.0.1 and < 3.0.0"
+smalto_lustre = ">= 2.0.0 and < 3.0.0"
+smalto_lustre_themes = ">= 2.0.0 and < 3.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/simple_blog/manifest.toml
+++ b/examples/simple_blog/manifest.toml
@@ -2,13 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "blogatto", version = "4.0.0", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "str", "webls"], source = "local", path = "../.." },
+  { name = "blogatto", version = "4.0.0", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "smalto", "smalto_lustre", "str", "webls"], source = "local", path = "../.." },
   { name = "casefold", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "casefold", source = "hex", outer_checksum = "F09530B6F771BB7B0BCACD3014089C20DFDA31775BA4793266C3814607C0A468" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "filespy", version = "0.7.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "1136C7DB512B83DF544CDA4632A633412281B48489428391DB0356F66423D7C0" },
   { name = "frontmatter", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "frontmatter", source = "hex", outer_checksum = "D7FF83A8D22A52867809681EE254A3F989169F92539299958879FE47737DAB7A" },
   { name = "fs", version = "11.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "DD00A61D89EAC01D16D3FC51D5B0EB5F0722EF8E3C1A3A547CD086957F3260A9" },
+  { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
+  { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
@@ -32,6 +34,9 @@ packages = [
   { name = "mork", version = "1.11.1", build_tools = ["gleam"], requirements = ["casefold", "gleam_regexp", "gleam_stdlib", "splitter"], otp_app = "mork", source = "hex", outer_checksum = "2DB4900FCCBB2CF9AB8C8438620FE00FC38CC6D340D52275D10769A4B43B3E5B" },
   { name = "odysseus", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "odysseus", source = "hex", outer_checksum = "6A97DA1075BDDEA8B60F47B1DFFAD49309FA27E73843F13A0AF32EA7087BA11C" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "smalto", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib", "houdini"], otp_app = "smalto", source = "hex", outer_checksum = "199C1A010F4CEE6E4DBE17C74A3F42326A1C89956C0D884B2BCC611104185CD1" },
+  { name = "smalto_lustre", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "smalto"], otp_app = "smalto_lustre", source = "hex", outer_checksum = "7C00BDC91CCE90240F4746E7BA250DC725D0D05D7B17B6B622DEEF921F78196D" },
+  { name = "smalto_lustre_themes", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "smalto_lustre"], otp_app = "smalto_lustre_themes", source = "hex", outer_checksum = "9C8EF34A035C0D6FBEBB3AA60759406934E67F744F42AFCB13680DC30BE0242D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
   { name = "telemetry", version = "1.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "2172E05A27531D3D31DD9782841065C50DD5C3C7699D95266B2EDD54C2DAFA1C" },
@@ -44,3 +49,6 @@ gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleam_time = { version = ">= 1.7.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 lustre = { version = ">= 5.6.0 and < 6.0.0" }
+smalto = { version = ">= 2.0.1 and < 3.0.0" }
+smalto_lustre = { version = ">= 2.0.0 and < 3.0.0" }
+smalto_lustre_themes = { version = ">= 2.0.0 and < 3.0.0" }

--- a/examples/simple_blog/src/simple_blog/blog.gleam
+++ b/examples/simple_blog/src/simple_blog/blog.gleam
@@ -8,6 +8,7 @@
 import blogatto/config
 import blogatto/config/feed
 import blogatto/config/markdown
+import blogatto/config/markdown/code
 import blogatto/config/robots
 import blogatto/config/sitemap
 import blogatto/post.{type Post}
@@ -17,16 +18,33 @@ import gleam/time/timestamp
 import lustre/attribute
 import lustre/element.{type Element}
 import lustre/element/html
+import smalto/lustre/themes
 
 const site_url = "https://example.com"
 
 pub fn config() -> config.Config(Nil) {
+  // Syntax highlighting configuration using CSS classes
+  let syntax_config =
+    code.default()
+    |> code.smalto_config(themes.material_light())
+
   // Markdown configuration: search the blog/ directory for posts
   let md_config =
     markdown.default()
     |> markdown.markdown_path("./blog")
     |> markdown.route_prefix("blog")
     |> markdown.template(blog_post_template)
+    |> markdown.syntax_highlighting(syntax_config)
+    |> markdown.pre(fn(children) {
+      html.pre([attribute.class("code-block")], children)
+    })
+    |> markdown.code(fn(language, children) {
+      let lang_class = case language {
+        option.Some(lang) -> "language-" <> lang
+        option.None -> ""
+      }
+      html.code([attribute.class(lang_class)], children)
+    })
 
   // RSS feed configuration
   let rss =

--- a/gleam.toml
+++ b/gleam.toml
@@ -26,6 +26,8 @@ maud = ">= 1.0.0 and < 2.0.0"
 mist = ">= 5.0.4 and < 6.0.0"
 mork = ">= 1.11.1 and < 2.0.0"
 simplifile = ">= 2.3.2 and < 3.0.0"
+smalto = ">= 2.0.0 and < 3.0.0"
+smalto_lustre = ">= 2.0.0 and < 3.0.0"
 str = ">= 2.0.1 and < 3.0.0"
 webls = ">= 1.6.1 and < 2.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,13 +9,15 @@ packages = [
   { name = "filespy", version = "0.7.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "1136C7DB512B83DF544CDA4632A633412281B48489428391DB0356F66423D7C0" },
   { name = "frontmatter", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "frontmatter", source = "hex", outer_checksum = "D7FF83A8D22A52867809681EE254A3F989169F92539299958879FE47737DAB7A" },
   { name = "fs", version = "11.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "DD00A61D89EAC01D16D3FC51D5B0EB5F0722EF8E3C1A3A547CD086957F3260A9" },
+  { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
+  { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
-  { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
+  { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
@@ -31,10 +33,12 @@ packages = [
   { name = "mist", version = "5.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7CED4B2D81FD547ADB093D97B9928B9419A7F58B8562A30A6CC17A252B31AD05" },
   { name = "mork", version = "1.11.1", build_tools = ["gleam"], requirements = ["casefold", "gleam_regexp", "gleam_stdlib", "splitter"], otp_app = "mork", source = "hex", outer_checksum = "2DB4900FCCBB2CF9AB8C8438620FE00FC38CC6D340D52275D10769A4B43B3E5B" },
   { name = "odysseus", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "odysseus", source = "hex", outer_checksum = "6A97DA1075BDDEA8B60F47B1DFFAD49309FA27E73843F13A0AF32EA7087BA11C" },
-  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "smalto", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib", "houdini"], otp_app = "smalto", source = "hex", outer_checksum = "199C1A010F4CEE6E4DBE17C74A3F42326A1C89956C0D884B2BCC611104185CD1" },
+  { name = "smalto_lustre", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "smalto"], otp_app = "smalto_lustre", source = "hex", outer_checksum = "7C00BDC91CCE90240F4746E7BA250DC725D0D05D7B17B6B622DEEF921F78196D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
-  { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
+  { name = "telemetry", version = "1.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "2172E05A27531D3D31DD9782841065C50DD5C3C7699D95266B2EDD54C2DAFA1C" },
   { name = "temporary", version = "1.0.0", build_tools = ["gleam"], requirements = ["envoy", "exception", "filepath", "gleam_crypto", "gleam_stdlib", "simplifile"], otp_app = "temporary", source = "hex", outer_checksum = "51C0FEF4D72CE7CA507BD188B21C1F00695B3D5B09D7DFE38240BFD3A8E1E9B3" },
   { name = "webls", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "webls", source = "hex", outer_checksum = "40317445399BFBBDCE8D5976C84ACD92319D4A6F1500A926F19AFCC9ED6639F1" },
 ]
@@ -56,6 +60,8 @@ maud = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 5.0.4 and < 6.0.0" }
 mork = { version = ">= 1.11.1 and < 2.0.0" }
 simplifile = { version = ">= 2.3.2 and < 3.0.0" }
+smalto = { version = ">= 2.0.0 and < 3.0.0" }
+smalto_lustre = { version = ">= 2.0.0 and < 3.0.0" }
 str = { version = ">= 2.0.1 and < 3.0.0" }
 temporary = { version = ">= 1.0.0 and < 2.0.0" }
 webls = { version = ">= 1.6.1 and < 2.0.0" }

--- a/src/blogatto/config/markdown.gleam
+++ b/src/blogatto/config/markdown.gleam
@@ -18,6 +18,7 @@
 ////   })
 //// ```
 
+import blogatto/config/markdown/code
 import blogatto/post.{type Post, type PostMetadata}
 import gleam/list
 import gleam/option.{type Option, None}
@@ -52,6 +53,11 @@ pub type MarkdownConfig(msg) {
     /// including the ability to place them outside of the route prefix or to use a completely different URL structure.
     /// If not provided the default builder will be used (i.e. `/{route_prefix?}/{lang}/{slug}/` or `/{route_prefix?}/{slug}/` if language is `None`).
     route_builder: Option(fn(PostMetadata) -> String),
+    /// Configuration for syntax highlighting in code blocks.
+    /// 
+    /// If not provided, syntax highlighting is disabled by default.
+    /// You can enable it with `markdown.syntax_highlighting(config, code.default())`, or customize it with your own configuration.
+    syntax_highlighting: Option(code.SyntaxHighlightingConfig(msg)),
     /// Optional custom template for rendering a blog post page.
     /// Receives the parsed `Post`, and all the other posts, and returns a full page element.
     /// When `None`, Blogatto uses a minimal default template.
@@ -145,6 +151,7 @@ pub fn default() -> MarkdownConfig(msg) {
     paths: [],
     route_prefix: None,
     route_builder: None,
+    syntax_highlighting: None,
     template: None,
   )
 }
@@ -238,6 +245,17 @@ pub fn route_builder(
   builder: fn(PostMetadata) -> String,
 ) -> MarkdownConfig(msg) {
   MarkdownConfig(..config, route_builder: option.Some(builder))
+}
+
+/// Set the configuration for syntax highlighting in code blocks.
+pub fn syntax_highlighting(
+  config: MarkdownConfig(msg),
+  syntax_highlighting: code.SyntaxHighlightingConfig(msg),
+) -> MarkdownConfig(msg) {
+  MarkdownConfig(
+    ..config,
+    syntax_highlighting: option.Some(syntax_highlighting),
+  )
 }
 
 /// Set a custom template function for rendering blog post pages.

--- a/src/blogatto/config/markdown/code.gleam
+++ b/src/blogatto/config/markdown/code.gleam
@@ -1,0 +1,316 @@
+//// This module exposes the configuration for syntax highlighting of code blocks in markdown files.
+
+import gleam/dict
+import gleam/list
+import lustre/element.{type Element}
+import smalto
+import smalto/grammar
+import smalto/languages/bash
+import smalto/languages/c
+import smalto/languages/cpp
+import smalto/languages/css
+import smalto/languages/dart
+import smalto/languages/dockerfile
+import smalto/languages/elixir
+import smalto/languages/erlang
+import smalto/languages/gleam
+import smalto/languages/go
+import smalto/languages/haskell
+import smalto/languages/html
+import smalto/languages/java
+import smalto/languages/javascript
+import smalto/languages/json
+import smalto/languages/kotlin
+import smalto/languages/lua
+import smalto/languages/markdown
+import smalto/languages/php
+import smalto/languages/python
+import smalto/languages/ruby
+import smalto/languages/rust
+import smalto/languages/scala
+import smalto/languages/sql
+import smalto/languages/swift
+import smalto/languages/toml
+import smalto/languages/typescript
+import smalto/languages/xml
+import smalto/languages/yaml
+import smalto/languages/zig
+import smalto/lustre as smalto_lustre
+
+/// The configuration for syntax highlighting of code blocks in markdown files.
+pub opaque type SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    /// Lustre components to render smalto tokens.
+    config: smalto_lustre.Config(msg),
+    /// A mapping from language names to their corresponding grammars.
+    languages: dict.Dict(String, fn() -> grammar.Grammar),
+  )
+}
+
+/// Returns the default configuration for syntax highlighting of code blocks in markdown files.
+pub fn default() -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    config: smalto_lustre.default_config(),
+    languages: dict.from_list([
+      #("bash", bash.grammar),
+      #("c", c.grammar),
+      #("cpp", cpp.grammar),
+      #("css", css.grammar),
+      #("dart", dart.grammar),
+      #("dockerfile", dockerfile.grammar),
+      #("elixir", elixir.grammar),
+      #("erlang", erlang.grammar),
+      #("gleam", gleam.grammar),
+      #("go", go.grammar),
+      #("golang", go.grammar),
+      #("haskell", haskell.grammar),
+      #("hs", haskell.grammar),
+      #("html", html.grammar),
+      #("java", java.grammar),
+      #("javascript", javascript.grammar),
+      #("js", javascript.grammar),
+      #("json", json.grammar),
+      #("kotlin", kotlin.grammar),
+      #("kt", kotlin.grammar),
+      #("lua", lua.grammar),
+      #("markdown", markdown.grammar),
+      #("md", markdown.grammar),
+      #("php", php.grammar),
+      #("python", python.grammar),
+      #("py", python.grammar),
+      #("rb", ruby.grammar),
+      #("ruby", ruby.grammar),
+      #("rs", rust.grammar),
+      #("rust", rust.grammar),
+      #("scala", scala.grammar),
+      #("sh", bash.grammar),
+      #("shell", bash.grammar),
+      #("sql", sql.grammar),
+      #("swift", swift.grammar),
+      #("toml", toml.grammar),
+      #("ts", typescript.grammar),
+      #("typescript", typescript.grammar),
+      #("xml", xml.grammar),
+      #("yaml", yaml.grammar),
+      #("yml", yaml.grammar),
+      #("zig", zig.grammar),
+    ]),
+  )
+}
+
+/// Highlights source code for the given language, returning highlighted Lustre elements.
+/// Returns Error(Nil) if the language is not in the configured languages dictionary.
+pub fn highlight(
+  config: SyntaxHighlightingConfig(msg),
+  language: String,
+  source: String,
+) -> Result(List(Element(msg)), Nil) {
+  case dict.get(config.languages, language) {
+    Ok(grammar_fn) -> {
+      let tokens = smalto.to_tokens(source, grammar_fn())
+      Ok(smalto_lustre.to_lustre(tokens, config.config))
+    }
+    Error(_) -> Error(Nil)
+  }
+}
+
+/// Sets the smalto_lustre configuration for syntax highlighting. This allows you to customize how different token types are rendered.
+pub fn smalto_config(
+  config: SyntaxHighlightingConfig(msg),
+  smalto_lustre_config: smalto_lustre.Config(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(..config, config: smalto_lustre_config)
+}
+
+/// Adds a new language to the syntax highlighting configuration.
+pub fn add_language(
+  config: SyntaxHighlightingConfig(msg),
+  grammar_fn: fn() -> grammar.Grammar,
+  language_names: List(String),
+) -> SyntaxHighlightingConfig(msg) {
+  let updated_languages =
+    list.fold(language_names, config.languages, fn(acc, lang) {
+      dict.insert(acc, lang, grammar_fn)
+    })
+  SyntaxHighlightingConfig(..config, languages: updated_languages)
+}
+
+pub fn keyword(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.keyword(config.config, element),
+  )
+}
+
+pub fn string(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.string(config.config, element),
+  )
+}
+
+pub fn number(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.number(config.config, element),
+  )
+}
+
+pub fn comment(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.comment(config.config, element),
+  )
+}
+
+pub fn function(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.function(config.config, element),
+  )
+}
+
+pub fn operator(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.operator(config.config, element),
+  )
+}
+
+pub fn punctuation(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.punctuation(config.config, element),
+  )
+}
+
+pub fn type_(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.type_(config.config, element),
+  )
+}
+
+pub fn module(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.module(config.config, element),
+  )
+}
+
+pub fn variable(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.variable(config.config, element),
+  )
+}
+
+pub fn constant(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.constant(config.config, element),
+  )
+}
+
+pub fn builtin(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.builtin(config.config, element),
+  )
+}
+
+pub fn tag(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.tag(config.config, element),
+  )
+}
+
+pub fn attribute(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.attribute(config.config, element),
+  )
+}
+
+pub fn selector(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.selector(config.config, element),
+  )
+}
+
+pub fn property(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.property(config.config, element),
+  )
+}
+
+pub fn regex(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.regex(config.config, element),
+  )
+}
+
+pub fn custom(
+  config: SyntaxHighlightingConfig(msg),
+  element: fn(String, String) -> Element(msg),
+) -> SyntaxHighlightingConfig(msg) {
+  SyntaxHighlightingConfig(
+    ..config,
+    config: smalto_lustre.custom(config.config, element),
+  )
+}

--- a/src/blogatto/internal/builder/blog.gleam
+++ b/src/blogatto/internal/builder/blog.gleam
@@ -6,6 +6,7 @@
 
 import blogatto/config
 import blogatto/config/markdown
+import blogatto/config/markdown/code
 import blogatto/error
 import blogatto/internal/date
 import blogatto/internal/excerpt
@@ -21,7 +22,7 @@ import gleam/result
 import gleam/string
 import gleam/time/timestamp
 import lustre/attribute
-import lustre/element
+import lustre/element.{type Element}
 import lustre/element/html
 import maud
 import maud/components as maud_components
@@ -276,7 +277,7 @@ fn parse_post(
     maud.render_markdown(
       markdown_file.content,
       mork_options(markdown_config.options),
-      to_maud_components(markdown_config.components),
+      to_maud_components(markdown_config),
     )
   let excerpt =
     rendered_components
@@ -454,13 +455,14 @@ fn get_frontmatter_optional_field(
 
 /// Convert blogatto `Components` to maud `Components`.
 fn to_maud_components(
-  c: markdown.Components(msg),
+  config: markdown.MarkdownConfig(msg),
 ) -> maud_components.Components(msg) {
+  let c = config.components
   maud_components.Components(
     a: c.a,
     blockquote: c.blockquote,
     checkbox: c.checkbox,
-    code: c.code,
+    code: code_component(config.syntax_highlighting, c.code),
     del: c.del,
     em: c.em,
     footnote: c.footnote,
@@ -490,6 +492,54 @@ fn to_maud_components(
     tr: c.tr,
     ul: c.ul,
   )
+}
+
+/// Helper function to convert blogatto `code.SyntaxHighlightingConfig` to a Maud component for rendering code blocks with syntax highlighting.
+/// When syntax highlighting is configured and a matching language grammar is found,
+/// the code block's text content is tokenized via smalto and rendered as highlighted Lustre elements.
+/// Otherwise, the original code component is used as-is.
+fn code_component(
+  syntax_highlighting: Option(code.SyntaxHighlightingConfig(msg)),
+  code_fn: fn(Option(String), List(Element(msg))) -> Element(msg),
+) -> fn(Option(String), List(Element(msg))) -> Element(msg) {
+  case syntax_highlighting {
+    option.None -> code_fn
+    option.Some(config) -> {
+      fn(language: Option(String), children: List(Element(msg))) -> Element(msg) {
+        case language {
+          option.Some(lang) -> {
+            // Extract raw text from children and unescape HTML entities,
+            // since element.to_string HTML-escapes text content.
+            // Each child is converted individually to avoid fragment
+            // comment markers that element.fragment adds.
+            let source =
+              children
+              |> list.map(element.to_string)
+              |> string.join("")
+              |> unescape_html()
+            case code.highlight(config, lang, source) {
+              Ok(highlighted) -> code_fn(language, highlighted)
+              Error(_) -> code_fn(language, children)
+            }
+          }
+          option.None -> code_fn(language, children)
+        }
+      }
+    }
+  }
+}
+
+/// Unescape HTML entities in a string. Used to recover raw source code from
+/// Lustre text elements which HTML-escape their content via houdini.
+/// The `&amp;` entity must be unescaped last to avoid double-unescaping
+/// sequences like `&amp;lt;`.
+fn unescape_html(html: String) -> String {
+  html
+  |> string.replace("&lt;", "<")
+  |> string.replace("&gt;", ">")
+  |> string.replace("&quot;", "\"")
+  |> string.replace("&#39;", "'")
+  |> string.replace("&amp;", "&")
 }
 
 /// Convert maud `Alignment` to blogatto `Alignment`.

--- a/test/blogatto/builder/blog_test.gleam
+++ b/test/blogatto/builder/blog_test.gleam
@@ -1,5 +1,6 @@
 import blogatto/config
 import blogatto/config/markdown
+import blogatto/config/markdown/code
 import blogatto/error
 import blogatto/internal/builder/blog as blog_builder
 import blogatto/internal/path
@@ -1938,5 +1939,199 @@ pub fn build_with_tasklists_disabled_does_not_render_checkboxes_test() {
       |> string.join("")
 
     html |> string.contains("type=\"checkbox\"") |> should.be_false
+  }
+}
+
+// --- Syntax highlighting integration ---
+
+fn config_with_syntax_highlighting(
+  output_dir: String,
+  blog_dir: String,
+) -> config.Config(msg) {
+  let md_config =
+    markdown.default()
+    |> markdown.markdown_path(blog_dir)
+    |> markdown.syntax_highlighting(code.default())
+
+  config.new("https://example.com")
+  |> config.output_dir(output_dir)
+  |> config.markdown(md_config)
+}
+
+pub fn build_with_syntax_highlighting_renders_highlighted_code_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "highlighted")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Highlighted Post",
+        "highlighted",
+        "2024-01-15 10:00:00",
+        "A post with a code block",
+        "```gleam\npub fn main() {}\n```\n",
+      ),
+    )
+
+    let assert [built_post] =
+      config_with_syntax_highlighting(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    // syntax highlighting should produce styled spans instead of plain text
+    html |> string.contains("<span") |> should.be_true
+    html |> string.contains("pub") |> should.be_true
+    html |> string.contains("fn") |> should.be_true
+    html |> string.contains("main") |> should.be_true
+  }
+}
+
+pub fn build_with_syntax_highlighting_falls_back_for_unknown_language_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "unknown-lang")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Unknown Lang Post",
+        "unknown-lang",
+        "2024-01-15 10:00:00",
+        "A post with an unknown language code block",
+        "```brainfuck\n+++.\n```\n",
+      ),
+    )
+
+    let assert [built_post] =
+      config_with_syntax_highlighting(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    // should still render the code block, just without highlighting
+    html |> string.contains("<code") |> should.be_true
+    html |> string.contains("+++.") |> should.be_true
+  }
+}
+
+pub fn build_with_syntax_highlighting_no_language_falls_back_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "no-lang")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "No Lang Post",
+        "no-lang",
+        "2024-01-15 10:00:00",
+        "A post with a code block without language",
+        "```\nsome plain code\n```\n",
+      ),
+    )
+
+    let assert [built_post] =
+      config_with_syntax_highlighting(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    // should render code block without highlighting (no language specified)
+    html |> string.contains("<code") |> should.be_true
+    html |> string.contains("some plain code") |> should.be_true
+  }
+}
+
+pub fn build_with_syntax_highlighting_handles_html_entities_in_code_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "html-entities")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "HTML Entities Post",
+        "html-entities",
+        "2024-01-15 10:00:00",
+        "Code with angle brackets",
+        "```rust\nfn main() {\n    let x: Vec<i32> = vec![1, 2, 3];\n}\n```\n",
+      ),
+    )
+
+    let assert [built_post] =
+      config_with_syntax_highlighting(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    // should handle angle brackets correctly in code
+    html |> string.contains("Vec") |> should.be_true
+    html |> string.contains("i32") |> should.be_true
+    html |> string.contains("fn") |> should.be_true
+  }
+}
+
+pub fn build_without_syntax_highlighting_renders_plain_code_test() {
+  let assert Ok(_) = {
+    use dir <- temporary.create(temporary.directory())
+    use blog <- temporary.create(temporary.directory())
+    let output = dir <> "/output"
+
+    let post_dir = create_post_dir(blog, "plain-code")
+    write_markdown(
+      post_dir,
+      "index.md",
+      markdown_content(
+        "Plain Code Post",
+        "plain-code",
+        "2024-01-15 10:00:00",
+        "A post with code but no syntax highlighting",
+        "```gleam\npub fn main() {}\n```\n",
+      ),
+    )
+
+    let assert [built_post] =
+      minimal_config(output, blog)
+      |> blog_builder.build()
+      |> should.be_ok
+
+    let html =
+      built_post.contents
+      |> list.map(element.to_string)
+      |> string.join("")
+
+    // without syntax highlighting, code should be plain text inside <code>
+    html |> string.contains("<code") |> should.be_true
+    html |> string.contains("pub fn main()") |> should.be_true
   }
 }

--- a/test/blogatto/config/markdown/code_test.gleam
+++ b/test/blogatto/config/markdown/code_test.gleam
@@ -1,0 +1,316 @@
+import blogatto/config/markdown/code
+import gleam/list
+import gleam/string
+import gleeunit/should
+import lustre/element
+import smalto/languages/gleam
+import smalto/languages/rust
+import smalto/lustre as smalto_lustre
+
+// --- highlight ---
+
+pub fn highlight_gleam_keyword_test() {
+  let config = code.default()
+  let result = code.highlight(config, "gleam", "pub fn main() {}")
+
+  result
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  // the output should contain highlighted tokens, not raw text
+  |> string.contains("pub")
+  |> should.be_true
+}
+
+pub fn highlight_gleam_produces_styled_spans_test() {
+  let config = code.default()
+  let result = code.highlight(config, "gleam", "let x = 1")
+
+  let html =
+    result
+    |> should.be_ok
+    |> element.fragment()
+    |> element.to_string()
+
+  // default config uses inline style spans for keywords
+  html |> string.contains("<span") |> should.be_true
+  html |> string.contains("let") |> should.be_true
+}
+
+pub fn highlight_python_test() {
+  let config = code.default()
+  let result = code.highlight(config, "python", "print(\"hello\")")
+
+  let html =
+    result
+    |> should.be_ok
+    |> element.fragment()
+    |> element.to_string()
+
+  html |> string.contains("print") |> should.be_true
+  html |> string.contains("hello") |> should.be_true
+}
+
+pub fn highlight_unknown_language_returns_error_test() {
+  let config = code.default()
+
+  code.highlight(config, "brainfuck", "+++.")
+  |> should.be_error
+  |> should.equal(Nil)
+}
+
+pub fn highlight_returns_multiple_elements_test() {
+  let config = code.default()
+  let elements =
+    code.highlight(config, "gleam", "pub fn main() {}")
+    |> should.be_ok
+
+  // tokenization should produce multiple elements (keywords, whitespace, punctuation, etc.)
+  list.length(elements) |> should.not_equal(0)
+}
+
+pub fn highlight_empty_source_returns_empty_list_test() {
+  let config = code.default()
+
+  code.highlight(config, "gleam", "")
+  |> should.be_ok
+  |> should.equal([])
+}
+
+pub fn highlight_preserves_source_content_test() {
+  let source = "import gleam/io\n\npub fn main() {\n  io.println(\"Hello!\")\n}"
+  let config = code.default()
+
+  let html =
+    code.highlight(config, "gleam", source)
+    |> should.be_ok
+    |> element.fragment()
+    |> element.to_string()
+
+  // all identifiers and strings from the source should appear in the output
+  html |> string.contains("import") |> should.be_true
+  html |> string.contains("gleam") |> should.be_true
+  html |> string.contains("pub") |> should.be_true
+  html |> string.contains("fn") |> should.be_true
+  html |> string.contains("main") |> should.be_true
+  html |> string.contains("Hello!") |> should.be_true
+}
+
+pub fn highlight_with_custom_keyword_renderer_test() {
+  let config =
+    code.default()
+    |> code.keyword(fn(text) { element.text("[KW:" <> text <> "]") })
+
+  let html =
+    code.highlight(config, "gleam", "pub fn main() {}")
+    |> should.be_ok
+    |> element.fragment()
+    |> element.to_string()
+
+  // custom renderer should wrap keywords
+  html |> string.contains("[KW:pub") |> should.be_true
+  html |> string.contains("[KW:fn") |> should.be_true
+}
+
+// --- Language aliases ---
+
+pub fn highlight_rs_alias_for_rust_test() {
+  let config = code.default()
+
+  code.highlight(config, "rs", "fn main() {}")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("fn")
+  |> should.be_true
+}
+
+pub fn highlight_js_alias_for_javascript_test() {
+  let config = code.default()
+
+  code.highlight(config, "js", "const x = 1;")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("const")
+  |> should.be_true
+}
+
+pub fn highlight_ts_alias_for_typescript_test() {
+  let config = code.default()
+
+  code.highlight(config, "ts", "const x: number = 1;")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("const")
+  |> should.be_true
+}
+
+pub fn highlight_py_alias_for_python_test() {
+  let config = code.default()
+
+  code.highlight(config, "py", "print(\"hello\")")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("print")
+  |> should.be_true
+}
+
+pub fn highlight_sh_alias_for_bash_test() {
+  let config = code.default()
+
+  code.highlight(config, "sh", "echo hello")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("echo")
+  |> should.be_true
+}
+
+pub fn highlight_shell_alias_for_bash_test() {
+  let config = code.default()
+
+  code.highlight(config, "shell", "echo hello")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("echo")
+  |> should.be_true
+}
+
+pub fn highlight_rb_alias_for_ruby_test() {
+  let config = code.default()
+
+  code.highlight(config, "rb", "puts \"hello\"")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("puts")
+  |> should.be_true
+}
+
+pub fn highlight_yml_alias_for_yaml_test() {
+  let config = code.default()
+
+  code.highlight(config, "yml", "key: value")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("key")
+  |> should.be_true
+}
+
+pub fn highlight_golang_alias_for_go_test() {
+  let config = code.default()
+
+  code.highlight(config, "golang", "func main() {}")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("func")
+  |> should.be_true
+}
+
+pub fn highlight_kt_alias_for_kotlin_test() {
+  let config = code.default()
+
+  code.highlight(config, "kt", "fun main() {}")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("fun")
+  |> should.be_true
+}
+
+pub fn highlight_hs_alias_for_haskell_test() {
+  let config = code.default()
+
+  code.highlight(config, "hs", "main = putStrLn \"hello\"")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("main")
+  |> should.be_true
+}
+
+pub fn highlight_md_alias_for_markdown_test() {
+  let config = code.default()
+
+  code.highlight(config, "md", "# Hello")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("Hello")
+  |> should.be_true
+}
+
+// --- smalto_config ---
+
+pub fn smalto_config_applies_custom_lustre_config_test() {
+  let custom_lustre_config = smalto_lustre.default_config()
+
+  let config =
+    code.default()
+    |> code.smalto_config(custom_lustre_config)
+
+  // highlighting should still work after setting a custom smalto config
+  code.highlight(config, "gleam", "pub fn main() {}")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("pub")
+  |> should.be_true
+}
+
+// --- add_language ---
+
+pub fn add_language_registers_new_language_test() {
+  let config =
+    code.default()
+    |> code.add_language(gleam.grammar, ["my_gleam", "myg"])
+
+  // the new alias should work
+  code.highlight(config, "my_gleam", "pub fn main() {}")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("pub")
+  |> should.be_true
+
+  // the second alias should also work
+  code.highlight(config, "myg", "let x = 1")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("let")
+  |> should.be_true
+}
+
+pub fn add_language_overrides_existing_language_test() {
+  // override "gleam" with the rust grammar
+  let config =
+    code.default()
+    |> code.add_language(rust.grammar, ["gleam"])
+
+  // "gleam" now uses the rust grammar, so Rust keywords should be highlighted
+  let html =
+    code.highlight(config, "gleam", "fn main() { let x = 1; }")
+    |> should.be_ok
+    |> element.fragment()
+    |> element.to_string()
+
+  html |> string.contains("fn") |> should.be_true
+  html |> string.contains("let") |> should.be_true
+}
+
+pub fn add_language_with_empty_names_does_not_change_config_test() {
+  let config = code.default()
+  let updated_config = code.add_language(config, gleam.grammar, [])
+
+  // unknown language should still fail — nothing was added
+  code.highlight(updated_config, "brainfuck", "+++.")
+  |> should.be_error
+  |> should.equal(Nil)
+}

--- a/test/blogatto/config/markdown_test.gleam
+++ b/test/blogatto/config/markdown_test.gleam
@@ -1,4 +1,5 @@
 import blogatto/config/markdown.{Center, Left, Right}
+import blogatto/config/markdown/code
 import gleam/option.{None, Some}
 import gleeunit/should
 import lustre/attribute
@@ -28,6 +29,12 @@ pub fn default_has_no_route_builder_test() {
 pub fn default_has_no_route_prefix_test() {
   let cfg = markdown.default()
   cfg.route_prefix
+  |> should.equal(None)
+}
+
+pub fn default_syntax_highlighting_is_default_test() {
+  let cfg = markdown.default()
+  cfg.syntax_highlighting
   |> should.equal(None)
 }
 
@@ -170,6 +177,21 @@ pub fn template_sets_template_function_test() {
 
   cfg.template
   |> should.be_some
+}
+
+// syntax highlighting setter is tested in code_test.gleam
+pub fn syntax_highlighting_sets_config_test() {
+  let custom_config =
+    code.default()
+    |> code.attribute(fn(text) {
+      html.span([attribute.class("code-attr")], [html.text(text)])
+    })
+  let cfg =
+    markdown.default()
+    |> markdown.syntax_highlighting(custom_config)
+
+  cfg.syntax_highlighting
+  |> should.equal(Some(custom_config))
 }
 
 // --- components setter ---


### PR DESCRIPTION
## Summary

- Add build-time syntax highlighting for fenced code blocks via `smalto` + `smalto_lustre`, eliminating the need for client-side JS highlighters
- New public module `blogatto/config/markdown/code` with opaque `SyntaxHighlightingConfig` type, 28 built-in language grammars (with aliases like `js`, `py`, `ts`, `rs`), and per-token-type rendering customization
- Opt-in integration via `markdown.syntax_highlighting(code.default())` — fully backwards compatible

Closes #27

## Test plan

- [x] Unit tests for `code.highlight` across multiple languages
- [x] Tests for all language aliases (js, py, ts, rs, sh, shell, rb, yml, golang, kt, hs, md)
- [x] Tests for unknown language error handling and empty source
- [x] Tests for custom token renderers and `smalto_config` setter
- [x] Tests for `add_language` (new, override, empty names)
- [x] Integration tests: highlighted code in built posts, fallback for unknown/missing language, HTML entity handling
- [x] All 412 tests pass