### PR TITLE
fix: RSS pubDate is now correctly being serialized with RFC882

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.0.2
+
+Released on 2026-03-20
+
+### Fixed
+
+- RSS pubDate is now correctly being serialized with RFC882
+  > webls was serializing with RFC3339. I've created this PR on webls <https://github.com/versecafe/webls/pull/9> to fix this behaviour. This fix on blogatto just bumps webls from 1.6.1 to 1.6.2
+
 ## 5.0.1
 
 Released on 2026-03-19

--- a/examples/simple_blog/manifest.toml
+++ b/examples/simple_blog/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "blogatto", version = "5.0.1", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "houdini", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "smalto", "smalto_lustre", "str", "webls"], source = "local", path = "../.." },
+  { name = "blogatto", version = "5.0.2", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "houdini", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "smalto", "smalto_lustre", "str", "webls"], source = "local", path = "../.." },
   { name = "casefold", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "casefold", source = "hex", outer_checksum = "F09530B6F771BB7B0BCACD3014089C20DFDA31775BA4793266C3814607C0A468" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -38,7 +38,7 @@ packages = [
   { name = "smalto_lustre_themes", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "smalto_lustre"], otp_app = "smalto_lustre_themes", source = "hex", outer_checksum = "50EAA03DB51FF7F3FA4457EC78D522A8C27B8DE11DE04407100473587E453499" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
-  { name = "webls", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "webls", source = "hex", outer_checksum = "40317445399BFBBDCE8D5976C84ACD92319D4A6F1500A926F19AFCC9ED6639F1" },
+  { name = "webls", version = "1.6.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "gtempo"], otp_app = "webls", source = "hex", outer_checksum = "515CA019E3B09FF7605D44ABBCDCF8FF56EC528AA29017741E0184278E3423DD" },
 ]
 
 [requirements]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "blogatto"
-version = "5.0.1"
+version = "5.0.2"
 description = "A Gleam framework for building static blogs with Lustre and Markdown. Generates HTML pages, RSS feeds, sitemaps, and robots.txt from markdown files with frontmatter, with multilingual support."
 repository = { type = "github", user = "veeso", repo = "blogatto" }
 licenses = ["MIT"]
@@ -30,7 +30,7 @@ simplifile = ">= 2.3.2 and < 3.0.0"
 smalto = ">= 3.0.0 and < 4.0.0"
 smalto_lustre = ">= 3.0.0 and < 4.0.0"
 str = ">= 2.0.1 and < 3.0.0"
-webls = ">= 1.6.1 and < 2.0.0"
+webls = ">= 1.6.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -38,7 +38,7 @@ packages = [
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
   { name = "temporary", version = "1.0.0", build_tools = ["gleam"], requirements = ["envoy", "exception", "filepath", "gleam_crypto", "gleam_stdlib", "simplifile"], otp_app = "temporary", source = "hex", outer_checksum = "51C0FEF4D72CE7CA507BD188B21C1F00695B3D5B09D7DFE38240BFD3A8E1E9B3" },
-  { name = "webls", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "webls", source = "hex", outer_checksum = "40317445399BFBBDCE8D5976C84ACD92319D4A6F1500A926F19AFCC9ED6639F1" },
+  { name = "webls", version = "1.6.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "gtempo"], otp_app = "webls", source = "hex", outer_checksum = "515CA019E3B09FF7605D44ABBCDCF8FF56EC528AA29017741E0184278E3423DD" },
 ]
 
 [requirements]
@@ -63,4 +63,4 @@ smalto = { version = ">= 3.0.0 and < 4.0.0" }
 smalto_lustre = { version = ">= 3.0.0 and < 4.0.0" }
 str = { version = ">= 2.0.1 and < 3.0.0" }
 temporary = { version = ">= 1.0.0 and < 2.0.0" }
-webls = { version = ">= 1.6.1 and < 2.0.0" }
+webls = { version = ">= 1.6.2 and < 2.0.0" }


### PR DESCRIPTION
webls was serializing with RFC3339. I've created this PR on webls <https://github.com/versecafe/webls/pull/9> to fix this behaviour. This fix on blogatto just bumps webls from 1.6.1 to 1.6.2

closes #38