### PR TITLE
feat: support timezone in frontmatter date field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.1.0
+
+Released on 2026-03-25
+
+### Added
+
+- support timezone in frontmatter date field
+  > Allow specifying a timezone in the frontmatter date field as either a
+  > UTC offset (+02:00) or an IANA timezone name (Europe/Helsinki).
+  > Dates without a timezone are still interpreted as UTC.
+  >
+  > The timezone database from the zones package is cached via
+  > persistent_term for efficient repeated lookups during builds.
+
 ## 5.0.2
 
 Released on 2026-03-20

--- a/docs/blog-posts.md
+++ b/docs/blog-posts.md
@@ -46,7 +46,7 @@ Your markdown content here...
 | Field | Format | Description |
 |-------|--------|-------------|
 | `title` | String | The post title |
-| `date` | `YYYY-MM-DD HH:MM:SS` | Publication date (UTC) |
+| `date` | `YYYY-MM-DD HH:MM:SS [timezone]` | Publication date (see [Date formats](#date-formats) below) |
 | `description` | String | A short description or excerpt |
 
 ### Optional fields
@@ -80,6 +80,28 @@ case dict.get(post.extras, "author") {
   Error(Nil) -> element.none()
 }
 ```
+
+### Date formats
+
+The `date` field supports three formats. All dates are internally normalized to UTC.
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| Naive | `2025-01-15 00:00:00` | Interpreted as UTC |
+| UTC offset | `2025-01-15 02:00:00 +02:00` | Converted to UTC using the given offset |
+| IANA timezone | `2025-01-15 02:00:00 Europe/Helsinki` | Converted to UTC using the [IANA timezone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
+
+When a timezone is specified, the date is converted to UTC before being stored in the `Post` type. This means you can write post dates in your local timezone without manually converting to UTC:
+
+```markdown
+---
+title: My Post
+date: 2025-01-15 10:30:00 America/New_York
+description: Written at 10:30 AM Eastern Time
+---
+```
+
+DST transitions are handled automatically — the correct offset is applied based on the date and the timezone's rules.
 
 ## Multilingual posts
 

--- a/examples/simple_blog/blog/getting-started/index.md
+++ b/examples/simple_blog/blog/getting-started/index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Blogatto
 slug: getting-started
-date: 2025-01-20 00:00:00
+date: 2025-01-20 00:00:00 Europe/Rome
 description: Learn how to set up your first static blog with Blogatto
 ---
 

--- a/examples/simple_blog/manifest.toml
+++ b/examples/simple_blog/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "blogatto", version = "5.0.2", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "houdini", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "smalto", "smalto_lustre", "str", "webls"], source = "local", path = "../.." },
+  { name = "blogatto", version = "5.1.0", build_tools = ["gleam"], requirements = ["filepath", "filespy", "frontmatter", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_time", "gtempo", "houdini", "lustre", "marceau", "maud", "mist", "mork", "simplifile", "smalto", "smalto_lustre", "str", "tzif", "webls", "zones"], source = "local", path = "../.." },
   { name = "casefold", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "casefold", source = "hex", outer_checksum = "F09530B6F771BB7B0BCACD3014089C20DFDA31775BA4793266C3814607C0A468" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
@@ -38,7 +38,9 @@ packages = [
   { name = "smalto_lustre_themes", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "lustre", "smalto_lustre"], otp_app = "smalto_lustre_themes", source = "hex", outer_checksum = "50EAA03DB51FF7F3FA4457EC78D522A8C27B8DE11DE04407100473587E453499" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
+  { name = "tzif", version = "1.1.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "tzif", source = "hex", outer_checksum = "04C8EBAFB7F6A6E61B8B0C16E06F96E7C7F76C31172EF07204CE9813B2E54AD2" },
   { name = "webls", version = "1.6.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "gtempo"], otp_app = "webls", source = "hex", outer_checksum = "515CA019E3B09FF7605D44ABBCDCF8FF56EC528AA29017741E0184278E3423DD" },
+  { name = "zones", version = "1.26010.1", build_tools = ["gleam"], requirements = ["tzif"], otp_app = "zones", source = "hex", outer_checksum = "6F79507E564D1F578C282BFE9241558744818D5957FE5CB859D64B5096F4211D" },
 ]
 
 [requirements]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "blogatto"
-version = "5.0.2"
+version = "5.1.0"
 description = "A Gleam framework for building static blogs with Lustre and Markdown. Generates HTML pages, RSS feeds, sitemaps, and robots.txt from markdown files with frontmatter, with multilingual support."
 repository = { type = "github", user = "veeso", repo = "blogatto" }
 licenses = ["MIT"]
@@ -30,7 +30,9 @@ simplifile = ">= 2.3.2 and < 3.0.0"
 smalto = ">= 3.0.0 and < 4.0.0"
 smalto_lustre = ">= 3.0.0 and < 4.0.0"
 str = ">= 2.0.1 and < 3.0.0"
+tzif = ">= 1.1.2 and < 2.0.0"
 webls = ">= 1.6.2 and < 2.0.0"
+zones = ">= 1.26010.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -38,7 +38,9 @@ packages = [
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "str", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "houdini", "odysseus"], otp_app = "str", source = "hex", outer_checksum = "9DABB9C97E3B88F13BD71E4ABF5781C6D12F88BFA4839D7FC9F99BED8E390C07" },
   { name = "temporary", version = "1.0.0", build_tools = ["gleam"], requirements = ["envoy", "exception", "filepath", "gleam_crypto", "gleam_stdlib", "simplifile"], otp_app = "temporary", source = "hex", outer_checksum = "51C0FEF4D72CE7CA507BD188B21C1F00695B3D5B09D7DFE38240BFD3A8E1E9B3" },
+  { name = "tzif", version = "1.1.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib", "gleam_time", "simplifile"], otp_app = "tzif", source = "hex", outer_checksum = "04C8EBAFB7F6A6E61B8B0C16E06F96E7C7F76C31172EF07204CE9813B2E54AD2" },
   { name = "webls", version = "1.6.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "gtempo"], otp_app = "webls", source = "hex", outer_checksum = "515CA019E3B09FF7605D44ABBCDCF8FF56EC528AA29017741E0184278E3423DD" },
+  { name = "zones", version = "1.26010.1", build_tools = ["gleam"], requirements = ["tzif"], otp_app = "zones", source = "hex", outer_checksum = "6F79507E564D1F578C282BFE9241558744818D5957FE5CB859D64B5096F4211D" },
 ]
 
 [requirements]
@@ -63,4 +65,6 @@ smalto = { version = ">= 3.0.0 and < 4.0.0" }
 smalto_lustre = { version = ">= 3.0.0 and < 4.0.0" }
 str = { version = ">= 2.0.1 and < 3.0.0" }
 temporary = { version = ">= 1.0.0 and < 2.0.0" }
+tzif = { version = ">= 1.1.2 and < 2.0.0" }
 webls = { version = ">= 1.6.2 and < 2.0.0" }
+zones = { version = ">= 1.26010.1 and < 2.0.0" }

--- a/src/blogatto/internal/date.gleam
+++ b/src/blogatto/internal/date.gleam
@@ -2,28 +2,57 @@
 ////
 //// Parses date strings in the `YYYY-MM-DD HH:MM:SS` format into
 //// `gleam/time/timestamp.Timestamp` values using the tempo library.
-//// All dates are interpreted as UTC.
+//// Dates without a timezone are interpreted as UTC.
+//// An optional timezone can be specified as a UTC offset (e.g. `+02:00`)
+//// or as an IANA timezone name (e.g. `Europe/Helsinki`).
 
 import blogatto/error
+import gleam/int
+import gleam/list
 import gleam/result
+import gleam/string
+import gleam/time/duration
 import gleam/time/timestamp.{type Timestamp}
 import tempo
 import tempo/datetime
 import tempo/naive_datetime
+import tzif/database
 
-/// Parse a date string in `YYYY-MM-DD HH:MM:SS` format into a UTC timestamp.
+/// Parse a date string into a UTC timestamp.
 ///
-/// The date and time components are separated by a single space. The time
-/// portion uses 24-hour format. Returns `FrontmatterInvalidDate` if the
-/// string does not match the expected format or contains out-of-range values.
+/// Accepted formats:
+/// - `YYYY-MM-DD HH:MM:SS` — interpreted as UTC
+/// - `YYYY-MM-DD HH:MM:SS +HH:MM` or `YYYY-MM-DD HH:MM:SS -HH:MM` — UTC offset
+/// - `YYYY-MM-DD HH:MM:SS Continent/City` — IANA timezone name
+///
+/// Returns `FrontmatterInvalidDate` if the string does not match any
+/// expected format or contains out-of-range values.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// parse("2023-01-25 00:00:00")
 /// // -> Ok(timestamp representing 2023-01-25T00:00:00Z)
+///
+/// parse("2023-01-25 02:00:00 +02:00")
+/// // -> Ok(timestamp representing 2023-01-25T00:00:00Z)
+///
+/// parse("2023-01-25 02:00:00 Europe/Helsinki")
+/// // -> Ok(timestamp representing 2023-01-25T00:00:00Z)
 /// ```
 pub fn parse(raw: String) -> Result(Timestamp, error.BlogattoError) {
+  let parts = string.split(raw, " ")
+  case list.length(parts) {
+    // "YYYY-MM-DD HH:MM:SS" — no timezone, interpret as UTC
+    2 -> parse_naive(raw)
+    // "YYYY-MM-DD HH:MM:SS <tz>" — has timezone part
+    3 -> parse_with_tz(raw)
+    _ -> Error(error.FrontmatterInvalidDate(raw))
+  }
+}
+
+/// Parse a date string without a timezone (e.g. "2023-01-25 00:00:00") into a UTC timestamp.
+fn parse_naive(raw: String) -> Result(Timestamp, error.BlogattoError) {
   let fmt = tempo.CustomNaive(format: "YYYY-MM-DD HH:mm:ss")
   raw
   |> naive_datetime.parse(fmt)
@@ -31,3 +60,86 @@ pub fn parse(raw: String) -> Result(Timestamp, error.BlogattoError) {
   |> result.map(datetime.to_timestamp)
   |> result.map_error(fn(_) { error.FrontmatterInvalidDate(raw) })
 }
+
+/// Parse a date string with a timezone at the end.
+/// Handles both UTC offsets (e.g. "+02:00") and IANA timezone names
+/// (e.g. "Europe/Helsinki") by first resolving names to offsets.
+fn parse_with_tz(raw: String) -> Result(Timestamp, error.BlogattoError) {
+  let fmt = tempo.Custom(format: "YYYY-MM-DD HH:mm:ss Z")
+  raw
+  |> resolve_tz_name
+  |> datetime.parse(fmt)
+  |> result.map(datetime.to_timestamp)
+  |> result.map_error(fn(_) { error.FrontmatterInvalidDate(raw) })
+}
+
+/// If the string ends with an IANA timezone name (e.g. "Europe/Helsinki"),
+/// replaces it with the equivalent UTC offset (e.g. "+02:00").
+/// If the last token does not contain a "/" it is returned unchanged,
+/// allowing offset formats like "+02:00" to pass through to tempo.
+fn resolve_tz_name(raw: String) -> String {
+  case string.split(raw, " ") {
+    [date_part, time_part, tz_part] ->
+      case string.contains(tz_part, "/") {
+        True -> {
+          let datetime_part = date_part <> " " <> time_part
+          case resolve_offset(datetime_part, tz_part) {
+            Ok(offset_str) -> datetime_part <> " " <> offset_str
+            // If resolution fails, return unchanged so parse_with_tz fails
+            // with FrontmatterInvalidDate
+            Error(_) -> raw
+          }
+        }
+        // Not a tz name, might be an offset like "+02:00" — pass through
+        False -> raw
+      }
+    _ -> raw
+  }
+}
+
+/// Look up the UTC offset for a timezone name at the given approximate datetime.
+/// The datetime string is parsed as naive (UTC) to get a reference timestamp
+/// for the lookup, which is close enough for correct DST resolution in
+/// nearly all cases.
+fn resolve_offset(datetime_str: String, tz_name: String) -> Result(String, Nil) {
+  let fmt = tempo.CustomNaive(format: "YYYY-MM-DD HH:mm:ss")
+
+  use naive <- result.try(
+    naive_datetime.parse(datetime_str, fmt) |> result.replace_error(Nil),
+  )
+  let approximate_ts = naive |> naive_datetime.as_utc |> datetime.to_timestamp
+
+  let db = get_tz_database()
+  use zone_params <- result.try(
+    database.get_zone_parameters(approximate_ts, tz_name, db)
+    |> result.replace_error(Nil),
+  )
+
+  Ok(format_offset(zone_params.offset))
+}
+
+/// Format a Duration offset as "+HH:MM" or "-HH:MM".
+fn format_offset(offset: duration.Duration) -> String {
+  let total_seconds = {
+    let #(seconds, _) = duration.to_seconds_and_nanoseconds(offset)
+    seconds
+  }
+  let sign = case total_seconds >= 0 {
+    True -> "+"
+    False -> "-"
+  }
+  let abs_seconds = int.absolute_value(total_seconds)
+  let hours = abs_seconds / 3600
+  let minutes = { abs_seconds % 3600 } / 60
+
+  sign
+  <> int.to_string(hours)
+  |> string.pad_start(2, "0")
+  <> ":"
+  <> int.to_string(minutes) |> string.pad_start(2, "0")
+}
+
+/// Get the timezone database, cached via persistent_term.
+/// The database is loaded from the prebuilt zones package on first access.
+@external(erlang, "blogatto_ffi", "get_tz_database")
+fn get_tz_database() -> database.TzDatabase

--- a/src/blogatto_ffi.erl
+++ b/src/blogatto_ffi.erl
@@ -1,0 +1,11 @@
+-module(blogatto_ffi).
+-export([get_tz_database/0]).
+
+get_tz_database() ->
+    try persistent_term:get(blogatto_tz_database)
+    catch
+        error:badarg ->
+            Db = zones:database(),
+            persistent_term:put(blogatto_tz_database, Db),
+            Db
+    end.

--- a/test/blogatto/internal/date_test.gleam
+++ b/test/blogatto/internal/date_test.gleam
@@ -65,3 +65,83 @@ pub fn parse_returns_error_for_wrong_separator_test() {
   |> should.be_error()
   |> should.equal(error.FrontmatterInvalidDate("2023/01/25 00:00:00"))
 }
+
+// Timezone offset tests
+
+pub fn parse_datetime_with_positive_utc_offset_test() {
+  // 2023-01-25 02:00:00 +02:00 should be 2023-01-25 00:00:00 UTC
+  date.parse("2023-01-25 02:00:00 +02:00")
+  |> should.be_ok()
+  |> should.equal(timestamp.from_calendar(
+    date: calendar.Date(year: 2023, month: calendar.January, day: 25),
+    time: calendar.TimeOfDay(hours: 0, minutes: 0, seconds: 0, nanoseconds: 0),
+    offset: duration.seconds(0),
+  ))
+}
+
+pub fn parse_datetime_with_negative_utc_offset_test() {
+  // 2023-01-24 19:00:00 -05:00 should be 2023-01-25 00:00:00 UTC
+  date.parse("2023-01-24 19:00:00 -05:00")
+  |> should.be_ok()
+  |> should.equal(timestamp.from_calendar(
+    date: calendar.Date(year: 2023, month: calendar.January, day: 25),
+    time: calendar.TimeOfDay(hours: 0, minutes: 0, seconds: 0, nanoseconds: 0),
+    offset: duration.seconds(0),
+  ))
+}
+
+pub fn parse_datetime_with_utc_offset_zero_test() {
+  date.parse("2023-01-25 00:00:00 +00:00")
+  |> should.be_ok()
+  |> should.equal(timestamp.from_calendar(
+    date: calendar.Date(year: 2023, month: calendar.January, day: 25),
+    time: calendar.TimeOfDay(hours: 0, minutes: 0, seconds: 0, nanoseconds: 0),
+    offset: duration.seconds(0),
+  ))
+}
+
+// IANA timezone name tests
+
+pub fn parse_datetime_with_iana_tz_name_test() {
+  // Europe/Helsinki is UTC+2 in January (EET, no DST)
+  // 2023-01-25 02:00:00 Europe/Helsinki should be 2023-01-25 00:00:00 UTC
+  date.parse("2023-01-25 02:00:00 Europe/Helsinki")
+  |> should.be_ok()
+  |> should.equal(timestamp.from_calendar(
+    date: calendar.Date(year: 2023, month: calendar.January, day: 25),
+    time: calendar.TimeOfDay(hours: 0, minutes: 0, seconds: 0, nanoseconds: 0),
+    offset: duration.seconds(0),
+  ))
+}
+
+pub fn parse_datetime_with_negative_iana_tz_test() {
+  // America/New_York is UTC-5 in January (EST, no DST)
+  // 2023-01-24 19:00:00 America/New_York should be 2023-01-25 00:00:00 UTC
+  date.parse("2023-01-24 19:00:00 America/New_York")
+  |> should.be_ok()
+  |> should.equal(timestamp.from_calendar(
+    date: calendar.Date(year: 2023, month: calendar.January, day: 25),
+    time: calendar.TimeOfDay(hours: 0, minutes: 0, seconds: 0, nanoseconds: 0),
+    offset: duration.seconds(0),
+  ))
+}
+
+pub fn parse_datetime_with_iana_tz_during_dst_test() {
+  // America/New_York is UTC-4 in July (EDT, DST active)
+  // 2023-07-25 20:00:00 America/New_York should be 2023-07-26 00:00:00 UTC
+  date.parse("2023-07-25 20:00:00 America/New_York")
+  |> should.be_ok()
+  |> should.equal(timestamp.from_calendar(
+    date: calendar.Date(year: 2023, month: calendar.July, day: 26),
+    time: calendar.TimeOfDay(hours: 0, minutes: 0, seconds: 0, nanoseconds: 0),
+    offset: duration.seconds(0),
+  ))
+}
+
+pub fn parse_returns_error_for_invalid_tz_name_test() {
+  date.parse("2023-01-25 00:00:00 Invalid/Timezone")
+  |> should.be_error()
+  |> should.equal(error.FrontmatterInvalidDate(
+    "2023-01-25 00:00:00 Invalid/Timezone",
+  ))
+}


### PR DESCRIPTION
## Summary

- Add optional timezone support to the frontmatter `date` field: accepts UTC offsets (`+02:00`) and IANA timezone names (`Europe/Helsinki`)
- Timezone database from `zones` package is cached via `persistent_term` for efficient repeated lookups
- Dates without a timezone remain interpreted as UTC (no breaking change)

Closes #40
