### PR TITLE
docs: README and getting started provide command for latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Blogatto generates your entire static site from a single configuration: blog pos
 
 ## Installation
 
+Blogatto is available on [Hex](https://hex.pm/packages/blogatto). Add it as a dependency to your project:
+
 ```sh
-gleam add blogatto@3
-gleam add lustre@5
+gleam add blogatto
 ```
 
 ## Quick start

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,10 +15,11 @@ This guide walks you through installing Blogatto and building your first static 
 
 ## Installation
 
-Add Blogatto to your Gleam project:
+Blogatto is available on [Hex](https://hex.pm/packages/blogatto). Add it as a dependency to your project:
+
 
 ```sh
-gleam add blogatto@3
+gleam add blogatto
 ```
 
 ## Project structure


### PR DESCRIPTION
In the [Getting Started](https://blogat.to/getting-started) tutorial, the provided command installs an old version of blogatto (3.0.0) which in turn depends on an old version of the `mist` and `glisten` packages thus causing a build error:

```
error: Unknown module value
    ┌─ .../build/packages/glisten/src/glisten/internal/acceptor.gleam:121:24
    │
121 │   let acceptors = list.range(from: 0, to: pool.pool_count)
    │                        ^^^^^

The module `gleam/list` does not have a `range` value.
```

This PR updates the documentation so that users are guided to the latest version of `blogatto`. I've also included a link to Hex for convenience as one may want to review the package in more detail before installing.