### PR TITLE
fix: resolve grammar from leading token of code fence info string

### DIFF
--- a/src/blogatto/config/post/code.gleam
+++ b/src/blogatto/config/post/code.gleam
@@ -2,6 +2,8 @@
 
 import gleam/dict
 import gleam/list
+import gleam/result
+import gleam/string
 import lustre/element.{type Element}
 import smalto
 import smalto/grammar
@@ -116,17 +118,47 @@ pub fn default() -> SyntaxHighlightingConfig(msg) {
 
 /// Highlights source code for the given language, returning highlighted Lustre elements.
 /// Returns Error(Nil) if the language is not in the configured languages dictionary.
+///
+/// The `language` argument is the code fence info string, which may carry more
+/// than the language name. CommonMark treats everything up to the first space as
+/// the language, and authors commonly append a title or filename after a `:`
+/// (e.g. `cpp:main.ino`). The full info string is matched first so explicitly
+/// registered language names keep working, then the leading token is tried as a
+/// fallback so these decorated fences still resolve to a grammar.
 pub fn highlight(
   config: SyntaxHighlightingConfig(msg),
   language: String,
   source: String,
 ) -> Result(List(Element(msg)), Nil) {
-  case dict.get(config.languages, language) {
+  let grammar_fn =
+    dict.get(config.languages, language)
+    |> result.or(dict.get(config.languages, language_token(language)))
+
+  case grammar_fn {
     Ok(grammar_fn) -> {
       let tokens = smalto.to_tokens(source, grammar_fn())
       Ok(smalto_lustre.to_lustre(tokens, config.config))
     }
     Error(_) -> Error(Nil)
+  }
+}
+
+/// Extracts the leading language token from a code fence info string by
+/// dropping anything from the first space or `:` onwards, e.g. both
+/// `cpp main.ino` and `cpp:main.ino` yield `cpp`. A string with neither
+/// separator is returned unchanged.
+fn language_token(language: String) -> String {
+  language
+  |> before_separator(" ")
+  |> before_separator(":")
+}
+
+/// Returns the part of `input` before the first occurrence of `separator`, or
+/// the whole `input` if the separator is absent.
+fn before_separator(input: String, separator: String) -> String {
+  case string.split_once(input, separator) {
+    Ok(#(before, _)) -> before
+    Error(_) -> input
   }
 }
 

--- a/test/blogatto/config/post/code_test.gleam
+++ b/test/blogatto/config/post/code_test.gleam
@@ -246,6 +246,53 @@ pub fn highlight_md_alias_for_markdown_test() {
   |> should.be_true
 }
 
+// --- Info string with title/filename suffix ---
+
+pub fn highlight_language_with_colon_suffix_test() {
+  let config = code.default()
+
+  // authors carry a filename/title after a colon, e.g. ```cpp:main.ino
+  code.highlight(config, "cpp:main.ino", "int x = 1;")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("int")
+  |> should.be_true
+}
+
+pub fn highlight_language_with_space_suffix_test() {
+  let config = code.default()
+
+  // CommonMark treats everything after the first space as extra info
+  code.highlight(config, "cpp main.ino", "int x = 1;")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("int")
+  |> should.be_true
+}
+
+pub fn highlight_bare_language_still_works_test() {
+  let config = code.default()
+
+  // the plain language name keeps resolving exactly as before
+  code.highlight(config, "cpp", "int x = 1;")
+  |> should.be_ok
+  |> element.fragment()
+  |> element.to_string()
+  |> string.contains("int")
+  |> should.be_true
+}
+
+pub fn highlight_unknown_language_with_suffix_returns_error_test() {
+  let config = code.default()
+
+  // an unknown leading token must still fail, suffix or not
+  code.highlight(config, "brainfuck:hello.bf", "+++.")
+  |> should.be_error
+  |> should.equal(Nil)
+}
+
 // --- smalto_config ---
 
 pub fn smalto_config_applies_custom_lustre_config_test() {


### PR DESCRIPTION
## Problem

`code.highlight` looks up the **entire** code fence info string in the languages dictionary:

```gleam
case dict.get(config.languages, language) {
```

When an author decorates a fence with a title or filename — a common convention — the info string no longer matches a bare language key, so highlighting silently falls back to unhighlighted text:

````
```cpp:main.ino      ← language is "cpp:main.ino", not "cpp" → Error(Nil)
```cpp main.ino      ← CommonMark: language is "cpp", rest is extra info → also missed
````

## Repro

```gleam
import blogatto/config/post/code

pub fn main() {
  let cfg = code.default()
  code.highlight(cfg, "cpp:main.ino", "int x = 1;")
  // before: Error(Nil) — block renders unhighlighted
  // after:  Ok([...highlighted spans...])
}
```

## Fix

Match the full info string first (so explicitly registered language names — including any with unusual characters — keep resolving exactly as before), then fall back to the **leading token**: everything before the first space or `:`. An unknown leading token still returns `Error(Nil)`, so behaviour for genuinely unsupported languages is unchanged.

The split is intentionally minimal — space and `:` only — matching CommonMark's "language is the text up to the first whitespace" rule plus the widespread `lang:filename` convention. No public API changes; the two new helpers are private.

## Tests

Added to `test/blogatto/config/post/code_test.gleam`:

- `cpp:main.ino` (colon suffix) highlights
- `cpp main.ino` (space suffix) highlights
- bare `cpp` still highlights (no regression)
- `brainfuck:hello.bf` (unknown leading token) still returns `Error(Nil)`

I verified the two positive tests fail without the source change and pass with it. Full suite: `506 passed, no failures`. `gleam format --check src test` is clean.

## Downstream impact

In a blog built on Blogatto, this currently forces a workaround: re-tokenising code blocks ourselves with the trimmed language after Blogatto's lookup misses. With this fix the framework's own `highlight` wrapper handles decorated fences directly, letting that workaround be removed.