### PR TITLE
fix: add heartbeats to close dead connections, also improve live reload script

### DIFF
--- a/src/blogatto/internal/dev/message.gleam
+++ b/src/blogatto/internal/dev/message.gleam
@@ -15,4 +15,7 @@ pub type RebuildMessage {
 /// Message type for server-sent events to the client.
 pub type SseMessage {
   Reload
+  /// Periodic self-message used to probe the SSE socket so dead connections
+  /// (clients that disconnected) can be detected and reaped.
+  Heartbeat
 }

--- a/src/blogatto/internal/dev/web_server.gleam
+++ b/src/blogatto/internal/dev/web_server.gleam
@@ -66,25 +66,25 @@ fn handle_request(
   }
 }
 
+/// Interval between SSE heartbeat probes, used to detect dead client
+/// connections.
+const sse_heartbeat_interval: Int = 15_000
+
 fn sse_init(
   rebuild_subject: Subject(message.RebuildMessage),
-) -> fn(Subject(message.SseMessage)) ->
-  Result(actor.Initialised(Nil, message.SseMessage, Nil), String) {
+) -> fn(Subject(message.SseMessage)) -> Subject(message.SseMessage) {
   fn(subject) {
     rebuild_actor.register_sse_client(rebuild_subject, subject)
-    actor.initialised(Nil)
-    |> Ok
+    process.send_after(subject, sse_heartbeat_interval, message.Heartbeat)
+    subject
   }
 }
 
 fn sse_loop(
-  state: Result(actor.Initialised(Nil, message.SseMessage, Nil), String),
+  subject: Subject(message.SseMessage),
   msg: message.SseMessage,
   conn: mist.SSEConnection,
-) -> actor.Next(
-  Result(actor.Initialised(Nil, message.SseMessage, Nil), String),
-  message.SseMessage,
-) {
+) -> actor.Next(Subject(message.SseMessage), message.SseMessage) {
   case msg {
     message.Reload -> {
       let event =
@@ -92,7 +92,22 @@ fn sse_loop(
         |> mist.event
         |> mist.event_name("reload")
       case mist.send_event(conn, event) {
-        Ok(_) -> actor.continue(state)
+        Ok(_) -> actor.continue(subject)
+        Error(_) -> actor.stop()
+      }
+    }
+    message.Heartbeat -> {
+      // Probe the socket, a failed write means the client disconnected, which 
+      // stops the actor.
+      let ping =
+        string_tree.from_string("ping")
+        |> mist.event
+        |> mist.event_name("ping")
+      case mist.send_event(conn, ping) {
+        Ok(_) -> {
+          process.send_after(subject, sse_heartbeat_interval, message.Heartbeat)
+          actor.continue(subject)
+        }
         Error(_) -> actor.stop()
       }
     }
@@ -137,7 +152,7 @@ fn serve_page(
   }
 }
 
-pub const live_reload_script = "<script>new EventSource('/__blogatto_dev/reload').addEventListener('reload',function(){location.reload()});</script>"
+pub const live_reload_script = "<script>(function(){var u='/__blogatto_dev/reload';var es=null;function open(){es=new EventSource(u);es.addEventListener('reload',function(){location.reload()});}function close(){if(es){es.close();es=null;}}open();window.addEventListener('pagehide',close);document.addEventListener('freeze',close);window.addEventListener('pageshow',function(e){if(e.persisted&&!es){open();}});})();</script>"
 
 /// Append the live reload script to HTML content. When `live_reload` is
 /// `True`, the script is injected just before `</body>`. If no closing body


### PR DESCRIPTION
# Description

This is my attempt to solve an issue I originally reported at #53, I decided to also add a heartbeat to the dev web server and that seems to properly handle the dead connections now. Here's an example below:

<img width="640" height="347" alt="blogatto_fix" src="https://github.com/user-attachments/assets/9d593ca1-7044-4b6c-af36-0bd9a49e1fca" />

- I'm running `watch -n 1 ss -tn 'sport = :3000'` in the first terminal.
- The fix works in both chrome-based browsers and firefox (at least as far as I could test).

I added comments in certain parts of the fix, as I changed the signatures of `sse_init` and `sse_loop`, I can go back and use the `Result`-based approach, but it really didn't make any sense that this type should be a `Result`, since this is an internal module no users are impacted.

- Closes #53 