### PR TITLE
docs: fix README example and add AI policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+# Description
+
+<!--
+Provide a brief description of the changes you made in this pull request. If your changes are related to a specific issue, please mention the issue number (e.g., "Fixes #123").
+-->
+
+## Checklist
+
+- [ ] I have read the [AI Policy](https://github.com/veeso/blogatto/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/blogatto/blob/main/CONTRIBUTING.md).
+- [ ] I ran `gleam test` and `gleam format --check src test`, and both pass.
+
+## AI Disclosure
+
+<!--
+Describe how you used AI tools in this contribution. If you did not use any AI tools, write "N/A".
+-->

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,64 @@
+# AI Policy
+
+The maintainers of this project don't want to interact directly with bots.
+Contributions must come from a human who understands the submitted code or text,
+can explain it, and is responsible for its quality as if they wrote it
+themselves. Using AI as a tool to help you write or reason about a contribution
+is fine; submitting AI output you don't understand, or relaying messages
+between a maintainer and an AI, is not.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) and disclosed as such. It must be
+accompanied by human commentary explaining the relevance and implications of
+the context.
+
+If you plan to contribute to Blogatto using AI tools, you **must** read,
+understand and follow this policy.
+
+## Disclosure
+
+You **must** disclose the use of AI tools in your contributions. You
+**must** perform this disclosure through the pull request template; filing
+PRs without using the pull request template is a violation of this policy.
+
+This applies to any AI tool that generated or substantially shaped the content
+you submit — code, prose or commit messages — including agents, chat assistants
+and AI-assisted editors. Mechanical editor autocompletion of a few characters
+does not need to be disclosed; if in doubt, disclose.
+
+## Translations
+
+AI is useful when communicating as a non-native English speaker. If you are
+using AI to edit your comments for this purpose, please take the time to ensure
+it reflects your own voice and ideas.
+
+## Provenance and licensing
+
+You are responsible for the provenance of anything you submit. AI tools can
+reproduce code or text from their training data verbatim, which may carry a
+license incompatible with this project. By contributing, you confirm the work
+is yours to submit under the project's license and does not infringe a third
+party's rights. The same standard that applies to code you write by hand.
+
+## Consequences
+
+Violating this policy may get your contribution rejected and, for repeated or
+egregious violations, get you blocked from the project without further warning.
+
+## Examples
+
+Examples of things that are not allowed:
+
+- Point an agent to a GitHub issue, ask it to solve the issue and open a PR,
+  without understanding the issue, the PR, or testing the solution yourself.
+- Copy responses from the AI when replying to questions from maintainers,
+  without understanding the question or the response.
+  In other words, you should not "play telephone" between your AI-generated code,
+  the reviewer, and the AI tool.
+
+## Inspiration
+
+This AI policy was inspired by:
+
+- [release-plz](https://github.com/release-plz/.github/blob/main/AI_POLICY.md)
+- [smista.ai](https://github.com/smista-ai/smista.ai/blob/main/AI_POLICY.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ First off, thank you for considering contributing to Blogatto! Every contributio
 
 Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
+If you use AI tools to help with your contribution, you **must** also read and follow our [AI Policy](AI_POLICY.md). It requires that contributions come from a human who understands the submitted work, and that AI usage is disclosed through the pull request template.
+
 ## Reporting Issues
 
 You can report bugs and request features on [GitHub Issues](https://github.com/veeso/blogatto/issues) or on [Codeberg](https://codeberg.org/veeso/blogatto/issues). Issues are typically tracked and resolved on GitHub.
@@ -110,7 +112,7 @@ All three checks run in CI and must pass before a PR can be merged.
 1. Fork the repository and create your branch from `main`
 2. Make your changes following the guidelines above
 3. Open a pull request targeting the `main` branch
-4. Fill in a clear description of what you changed and why
+4. Fill in the pull request template, including a clear description of what you changed and why, and the AI disclosure required by the [AI Policy](AI_POLICY.md)
 
 A maintainer will review your PR. At least one maintainer approval is required before merging.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import blogatto/config/post
 import blogatto/config/robots
 import blogatto/config/sitemap
 import blogatto/error
-import blogatto/post.{type Post}
+import blogatto/post.{type Post} as _
 import gleam/io
 import gleam/list
 import gleam/time/timestamp
@@ -61,7 +61,7 @@ pub fn main() {
     post.default()
     |> post.path("./blog")
     |> post.route_prefix("blog")
-    |> post.h1(fn(id, children) {
+    |> post.h1(fn(_attributes, id, children) {
       html.h1([attribute.id(id), attribute.class("post-title")], children)
     })
 


### PR DESCRIPTION
# Description

This pull request bundles two documentation changes.

First, it fixes the quick start example in the README. The example imported the same name twice, which would stop it from compiling, and one of the heading callbacks was missing an argument. Anyone copying the example now gets code that builds.

Second, it adds an AI Policy and a pull request template, both adapted from the smista.ai project. The AI Policy explains that contributions must come from a person who understands the work, and that any use of AI tools must be disclosed. The new pull request template asks contributors to confirm they read the policy and to describe how they used AI tools. The contributing guide now points to the AI Policy as well.

## Checklist

- [x] I have read the [AI Policy](https://github.com/veeso/blogatto/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/blogatto/blob/main/CONTRIBUTING.md).
- [x] I ran `gleam test` and `gleam format --check src test`, and both pass.

## AI Disclosure

The README fix was found and applied with the help of an AI coding assistant, and verified by compiling the example. The AI Policy, the pull request template, and the contributing guide update were drafted with the same assistant by adapting the smista.ai versions. A human reviewed all of the changes.
